### PR TITLE
fix(publish): atomic bump+publish per scope with should-publish filter

### DIFF
--- a/.github/actions/cfdi/action.yml
+++ b/.github/actions/cfdi/action.yml
@@ -8,8 +8,11 @@ inputs:
 
 outputs:
   scopes:
-    description: 'JSON array of bumped scopes'
+    description: 'JSON array of publishable scopes'
     value: ${{ steps.script.outputs.scopes }}
+  branch:
+    description: 'Target branch name'
+    value: ${{ steps.script.outputs.branch }}
 
 runs:
   using: 'composite'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,30 +54,60 @@ jobs:
         if: steps.branch.outputs.is_main == 'true'
         run: |
           SCOPES='${{ steps.cfdi.outputs.scopes }}'
+          FAILED=""
           for scope in $(echo "$SCOPES" | jq -r '.[]'); do
-            echo "Publishing version-policy: $scope"
-            rush publish -p -b main --version-policy "$scope" --include-all --set-access-level=public
+            echo "=== Publishing $scope ==="
+            rush version --version-policy "$scope" --bump
+            if rush publish -p -b main --version-policy "$scope" --include-all --set-access-level=public; then
+              git add -A
+              echo "✓ $scope published"
+            else
+              FAILED="$FAILED $scope"
+              git checkout -- .
+              echo "::warning::✗ $scope failed, reverted"
+            fi
           done
+          if [ -n "$FAILED" ]; then
+            echo "::error::Failed scopes:$FAILED"
+            exit 1
+          fi
 
       - name: Publish (prerelease)
         if: steps.branch.outputs.is_main == 'false'
         run: |
+          TAG="${{ steps.branch.outputs.name }}"
           SCOPES='${{ steps.cfdi.outputs.scopes }}'
+          FAILED=""
           for scope in $(echo "$SCOPES" | jq -r '.[]'); do
-            echo "Publishing version-policy: $scope"
-            rush publish --publish --version-policy "$scope" --tag ${{ steps.branch.outputs.name }} --include-all --set-access-level=public --apply
+            echo "=== Publishing $scope ==="
+            rush version --version-policy "$scope" --bump --override-bump prerelease --override-prerelease-id "$TAG"
+            if rush publish --publish --version-policy "$scope" --tag "$TAG" --include-all --set-access-level=public --apply; then
+              git add -A
+              echo "✓ $scope published"
+            else
+              FAILED="$FAILED $scope"
+              git checkout -- .
+              echo "::warning::✗ $scope failed, reverted"
+            fi
           done
+          if [ -n "$FAILED" ]; then
+            echo "::error::Failed scopes:$FAILED"
+            exit 1
+          fi
 
       - name: Commit version bumps
         run: |
           BRANCH="${{ steps.branch.outputs.name }}"
-          git add -A
-          if [ "$BRANCH" = "main" ]; then
-            git commit -m "chore: release $(date +%Y-%m-%d)" || echo "No changes to commit"
+          if [ -n "$(git diff --cached --name-only)" ]; then
+            if [ "$BRANCH" = "main" ]; then
+              git commit -m "chore: release $(date +%Y-%m-%d)"
+            else
+              git commit -m "chore: prerelease $BRANCH $(date +%Y-%m-%d)"
+            fi
+            git push origin $BRANCH
           else
-            git commit -m "chore: prerelease $BRANCH $(date +%Y-%m-%d)" || echo "No changes to commit"
+            echo "No changes to commit"
           fi
-          git push origin $BRANCH
 
       - name: Create GitHub Releases
         run: node common/scripts/github-release.js

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,31 +2,31 @@
   {
     "policyName": "xml",
     "definitionName": "lockStepVersion",
-    "version": "4.0.18-dev.0",
+    "version": "4.0.18-dev.1",
     "nextBump": "patch"
   },
   {
     "policyName": "complementos",
     "definitionName": "lockStepVersion",
-    "version": "4.0.17-dev.0",
+    "version": "4.0.17-dev.1",
     "nextBump": "patch"
   },
   {
     "policyName": "catalogs",
     "definitionName": "lockStepVersion",
-    "version": "4.0.16-dev.0",
+    "version": "4.0.16-dev.1",
     "nextBump": "patch"
   },
   {
     "policyName": "csd",
     "definitionName": "lockStepVersion",
-    "version": "4.0.16-dev.0",
+    "version": "4.0.16-dev.1",
     "nextBump": "patch"
   },
   {
     "policyName": "csf",
     "definitionName": "lockStepVersion",
-    "version": "4.0.16-dev.0",
+    "version": "4.0.16-dev.1",
     "nextBump": "patch"
   },
   {
@@ -74,7 +74,7 @@
   {
     "policyName": "xsd",
     "definitionName": "lockStepVersion",
-    "version": "4.0.17-dev.0",
+    "version": "4.0.17-dev.1",
     "nextBump": "patch"
   },
   {

--- a/common/scripts/github-actions.js
+++ b/common/scripts/github-actions.js
@@ -1,27 +1,4 @@
 
-async function execa(command, params) {
-  const { spawn } = require('child_process');
-  const child = spawn(command, params);
-
-  let data = '';
-  for await (const chunk of child.stdout) {
-    //console.log('stdout chunk: ' + chunk);
-    data += chunk;
-  }
-  let error = '';
-  for await (const chunk of child.stderr) {
-    //console.error('stderr chunk: ' + chunk);
-    error += chunk;
-  }
-  const exitCode = await new Promise((resolve, reject) => {
-    child.on('close', resolve);
-  });
-
-  if (exitCode) {
-    throw new Error(`subprocess error exit ${exitCode}, ${error}`);
-  }
-  return data;
-}
 function getDependences(scope) {
   const dependencies = {
     xml: {
@@ -201,7 +178,6 @@ module.exports = async ({ github, context, core }) => {
   console.log("branch:", branch);
   console.log("eventName:", context.eventName);
 
-  const branchs =  ['next','beta', 'alpha','dev']
   const eventName = context.eventName
   let commits = context.payload.commits || [];
 
@@ -219,26 +195,18 @@ module.exports = async ({ github, context, core }) => {
     commits = commits_local.map(({commit})=>commit)
   }
   const scopes =  getScopes(commits);
-  console.log("commits", scopes);
+  console.log("scopes from commits", scopes);
 
-  for (var i = 0; i < scopes.length; i++) {
-    const scope = scopes[i];
-    const comands = [
-      'version',
-      '--version-policy',
-      scope,
-      '--bump',
-    ]
-    if (branchs.includes(branch)) {
-      comands.push('--override-bump');
-      comands.push('prerelease');
-      comands.push('--override-prerelease-id');
-      comands.push(branch);
-    }
-    console.log(comands);
-    const data = await execa('rush', comands);
-    console.log(data);
-  }
+  // Filtrar scopes que no tienen shouldPublish: true
+  const rushJson = JSON.parse(require('fs').readFileSync('./rush.json', 'utf8'));
+  const publishablePolicies = new Set(
+    rushJson.projects
+      .filter(p => p.shouldPublish && p.versionPolicyName)
+      .map(p => p.versionPolicyName)
+  );
+  const filteredScopes = scopes.filter(s => publishablePolicies.has(s));
+  console.log("publishable scopes", filteredScopes);
 
-  core.setOutput('scopes', JSON.stringify(scopes));
+  core.setOutput('scopes', JSON.stringify(filteredScopes));
+  core.setOutput('branch', branch);
 };

--- a/packages/cfdi/catalogos/package.json
+++ b/packages/cfdi/catalogos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/catalogos",
-  "version": "4.0.16-dev.0",
+  "version": "4.0.16-dev.1",
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cfdi/complementos/package.json
+++ b/packages/cfdi/complementos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/complementos",
-  "version": "4.0.17-dev.0",
+  "version": "4.0.17-dev.1",
   "description": "Libreria para generar complementos del cfdi V4.0",
   "homepage": "https://cfdi.recreando.dev",
   "license": "MIT",

--- a/packages/cfdi/csd/package.json
+++ b/packages/cfdi/csd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/csd",
-  "version": "4.0.16-dev.0",
+  "version": "4.0.16-dev.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cfdi/csf/package.json
+++ b/packages/cfdi/csf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/csf",
-  "version": "4.0.16-dev.0",
+  "version": "4.0.16-dev.1",
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cfdi/xml/package.json
+++ b/packages/cfdi/xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/xml",
-  "version": "4.0.18-dev.0",
+  "version": "4.0.18-dev.1",
   "description": "Libreria para crear y sellar xml cfdi V4.0",
   "homepage": "https://cfdi.recreando.dev",
   "license": "MIT",

--- a/packages/cfdi/xsd/package.json
+++ b/packages/cfdi/xsd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/xsd",
-  "version": "4.0.17-dev.0",
+  "version": "4.0.17-dev.1",
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- **github-actions.js**: removed bump loop, now only computes and outputs filtered scopes (excludes `shouldPublish: false`)
- **publish.yml**: bump+publish is now atomic per scope — if publish fails, `git checkout -- .` reverts that scope's changes while staged (successful) changes are preserved
- **version-policies.json + package.json**: synced 6 packages with npm (xml, complementos, xsd, csd, csf, catalogos) to match published -dev.1 versions
- 15 empty commits to trigger publish for all publishable packages

## Key changes
- `getDependences('utils')` includes `pdf` but it gets filtered out because `pdf` has `shouldPublish: false`
- If a scope fails to publish, its version bump is reverted — only successful publishes get committed
- `git add -A` after each successful publish stages changes; `git checkout -- .` after failure reverts unstaged changes

## Test plan
- [ ] Verify `publishable scopes` log excludes pdf, cancelacion, designs, etc.
- [ ] Verify all 15 publishable scopes bump and publish successfully
- [ ] Verify failed scopes get reverted (no orphan version bumps)