### PR TITLE
fix(publish): remove --apply, add summary, fix version commit

### DIFF
--- a/.claude/skills/cfdi-complemento/SKILL.md
+++ b/.claude/skills/cfdi-complemento/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: cfdi-complemento
+description: >
+  Guide for adding new SAT fiscal complement (complemento) support to the cfdi-node monorepo.
+  Use this skill whenever someone wants to: add a new complemento, implement a missing complement,
+  create support for a SAT fiscal addon (like Hidrocarburos, Nomina, CartaPorte, etc.),
+  or asks about how complements work in this project. Also trigger when the user mentions
+  "complemento", "complement", "addon fiscal", "XSD del SAT", or references any SAT namespace
+  like "http://www.sat.gob.mx/...". Even if the user just says "add hidrocarburos support"
+  or "implement pagos" without explicitly mentioning "complement", this skill applies.
+---
+
+# Adding a New Complemento to cfdi-node
+
+This guide walks you through implementing a new SAT fiscal complement in the `@cfdi/complementos` package. The project lives at `packages/cfdi/complementos/` inside the Rush monorepo.
+
+## Understanding the Architecture
+
+Every CFDI complement follows the same core idea: it's a TypeScript class that builds an XML fragment with the right SAT namespace, schema location, and attributes. The class extends the abstract `Complemento<T>` base class, which handles namespace registration and exposes `getComplement()` — the standardized method the CFDI builder uses to attach the complement to the invoice XML.
+
+The base class (`src/Complemento.ts`) does the heavy lifting:
+
+```typescript
+abstract class Complemento<T = any> {
+  public complemento: T = {} as T;
+  // Manages: xmlns, key, xmlnskey, schemaLocation
+  constructor(config: { xmlns: string; key: string; xsd: string }) { ... }
+  public getComplement(): ComplementsReturn<T> { ... }
+}
+```
+
+You define your XML structure as a generic type `T`, pass the SAT namespace info to `super()`, and build the complement data in your constructor and methods.
+
+## Step-by-Step: Adding a New Complement
+
+### 1. Gather SAT Requirements
+
+Before writing code, you need these from the SAT specification or XSD:
+
+- **Namespace URI** (xmlns): e.g. `http://www.sat.gob.mx/hidrocarburospetroliferos`
+- **XSD URL**: e.g. `http://www.sat.gob.mx/sitio_internet/cfd/hidrocarburos/hidrocarburos.xsd`
+- **XML element name with prefix**: e.g. `hidrocarburos:Hidrocarburos`
+- **Attributes and nested elements**: read the XSD to understand the full structure
+- **Catalogs/enums**: fixed value sets like permit types, product codes, etc.
+- **Whether it's a root complement or concept-level complement**:
+  - Root complements go in `Comprobante/Complemento/` (most common)
+  - Concept complements go in `Comprobante/Conceptos/Concepto/ComplementoConcepto/`
+
+### 2. Create the Type Definitions
+
+Create types inside `src/4.0/<nombre>/type/`.
+
+#### Attributes Interface
+
+Every XML element has an `_attributes` property. Define an interface for it:
+
+```typescript
+// Example: src/4.0/hidrocarburos/type/hidrocarburos.xslt.ts
+
+export interface XmlHidrocarburos {
+  _attributes: XmlHidrocarburosAttributes;
+}
+
+export interface XmlHidrocarburosAttributes {
+  Version: string;
+  TipoPermiso: string;    // Use enum type if you define one
+  NumeroPermiso: string;
+  ClaveHYP: string;
+  SubProductoHYP?: string; // Optional attributes get '?'
+}
+```
+
+The naming convention is: `Xml` + PascalCase name for the main interface, and `Xml` + PascalCase name + `Attributes` for the attributes.
+
+#### Nested Elements
+
+If the complement has child elements, add them to the main interface using the namespaced key:
+
+```typescript
+export interface XmlAerolineas {
+  _attributes: XmlAerolineasAttributes;
+  'aerolineas:OtrosCargos': XmlAerolineasOtrosCargos;  // nested element
+}
+```
+
+Arrays of elements use `Type[]`:
+
+```typescript
+export interface XmlAerolineasOtrosCargos {
+  _attributes?: XmlAerolineasOtrosCargosAttributes;
+  'aerolineas:Cargo': XmlAerolineasCargo[];  // array of children
+}
+```
+
+#### Enums (if needed)
+
+If the SAT defines a fixed catalog of values, create an enum file:
+
+```typescript
+// Example: hidrocarburos.enum.ts
+
+export enum TipoPermiso {
+  PER06 = 'PER06',
+  PER07 = 'PER07',
+  PER08 = 'PER08',
+}
+
+export const TipoPermisoList = [
+  { value: 'PER06', label: 'Distribuidor de petroliferos' },
+  { value: 'PER07', label: 'Expendio al publico de petroliferos' },
+  { value: 'PER08', label: 'Distribuidor y expendio al publico' },
+];
+```
+
+#### Barrel Export
+
+Create an `index.ts` in the type directory:
+
+```typescript
+export * from './hidrocarburos.xslt';
+// export * from './hidrocarburos.enum';  // if enums exist
+```
+
+### 3. Create the Complement Class
+
+Create the class at `src/4.0/<nombre>/<Nombre>.ts`.
+
+#### Simple Complement (flat attributes only)
+
+This is the most common case:
+
+```typescript
+// src/4.0/hidrocarburos/Hidrocarburos.ts
+
+import { XmlHidrocarburos, XmlHidrocarburosAttributes } from './type/hidrocarburos.xslt';
+import { Complemento } from '../../Complemento';
+
+const xmlns = 'http://www.sat.gob.mx/hidrocarburospetroliferos';
+const xsd = 'http://www.sat.gob.mx/sitio_internet/cfd/hidrocarburos/hidrocarburos.xsd';
+
+export class Hidrocarburos extends Complemento<XmlHidrocarburos> {
+  public complemento: XmlHidrocarburos = {} as XmlHidrocarburos;
+
+  constructor(attributes: XmlHidrocarburosAttributes) {
+    super({ key: 'hidrocarburos:Hidrocarburos', xmlns, xsd });
+    this.complemento._attributes = attributes;
+  }
+}
+```
+
+The three values passed to `super()` are critical:
+- `key`: the namespaced XML element name (prefix:ElementName)
+- `xmlns`: the SAT namespace URI
+- `xsd`: the full URL to the XSD schema file
+
+#### Complex Complement (with nested elements)
+
+When a complement has child elements, add builder methods. Follow the Aerolineas pattern:
+
+```typescript
+export class MiComplemento extends Complemento<XmlMiComplemento> {
+  public complemento: XmlMiComplemento = {} as XmlMiComplemento;
+
+  constructor(attributes: XmlMiComplementoAttributes) {
+    super({ key: 'prefix:ElementName', xmlns, xsd });
+    this.complemento._attributes = attributes;
+  }
+
+  addChild(attributes: XmlChildAttributes): void {
+    if (!this.complemento['prefix:Children']) {
+      this.complemento['prefix:Children'] = [];
+    }
+    this.complemento['prefix:Children'].push({
+      _attributes: attributes,
+    });
+  }
+}
+```
+
+Important behaviors:
+- Initialize arrays/objects lazily (check if they exist first)
+- Throw descriptive errors if ordering matters (e.g., parent must exist before adding children)
+- Use `void` return type for builder methods (unless you want fluent chaining with `this`)
+
+### 4. Create the Barrel Export
+
+Add an `index.ts` in the complement directory:
+
+```typescript
+// src/4.0/hidrocarburos/index.ts
+export * from './Hidrocarburos';
+export * from './type';
+```
+
+### 5. Register the Complement
+
+This is where you wire the new complement into the rest of the system. There are several files to update:
+
+#### a) Main package export — `src/index.ts`
+
+Add the export line with the other 4.0 exports:
+
+```typescript
+export * from './4.0/hidrocarburos';
+```
+
+#### b) Complement interfaces — `src/types/tags/complements.interface.ts`
+
+**For root complements**, add to `XmlComplements`:
+
+```typescript
+export interface XmlComplements extends AnyKey {
+  // ... existing entries ...
+  'hidrocarburos:Hidrocarburos'?: XmlHidrocarburos;
+}
+```
+
+**For concept-level complements**, add to `XmlComplementsConcepts`:
+
+```typescript
+export interface XmlComplementsConcepts extends AnyKey {
+  // ... existing entries ...
+  'myprefix:MyElement'?: XmlMyType;
+}
+```
+
+#### c) Type unions — same file
+
+Add the class to `ComlementType` (note: the typo "Comlement" is intentional, it exists this way in the codebase — don't "fix" it):
+
+```typescript
+export declare type ComlementType =
+  | // ... existing ...
+  | Hidrocarburos
+  | Complemento;
+```
+
+Add the XML type to `ComplementTypeXml<T>`:
+
+```typescript
+export declare type ComplementTypeXml<T> =
+  | // ... existing ...
+  | XmlHidrocarburos
+  | T;
+```
+
+#### d) Namespace attributes — same file
+
+Add namespace declaration to `XmlComplementsAttributes`:
+
+```typescript
+'xmlns:hidrocarburos'?: string;  // http://www.sat.gob.mx/hidrocarburospetroliferos
+```
+
+Add to `XmlnsComplementsLinks`:
+
+```typescript
+hidrocarburos?: string;  // http://www.sat.gob.mx/hidrocarburospetroliferos
+```
+
+### 6. Write Tests
+
+Create a test file using Vitest:
+
+```typescript
+// test/hidrocarburos.test.ts
+import { describe, it, expect } from 'vitest';
+import { Hidrocarburos } from '../src/4.0/hidrocarburos/Hidrocarburos';
+
+describe('Hidrocarburos', () => {
+  it('should create a valid complement with required attributes', () => {
+    const hidro = new Hidrocarburos({
+      Version: '1.0',
+      TipoPermiso: 'PER06',
+      NumeroPermiso: 'PL/12345/EXP/2026',
+      ClaveHYP: '01',
+      SubProductoHYP: '0101',
+    });
+
+    const result = hidro.getComplement();
+    expect(result.key).toBe('hidrocarburos:Hidrocarburos');
+    expect(result.xmlns).toBe('http://www.sat.gob.mx/hidrocarburospetroliferos');
+    expect(result.complement._attributes.Version).toBe('1.0');
+    expect(result.schemaLocation).toHaveLength(2);
+  });
+});
+```
+
+Tests should validate: correct `key`, `xmlns`, `schemaLocation`, attributes, nested element construction, and error cases.
+
+Run with: `npm run test:ci` from the package directory, or `rush test:ci` from the monorepo root.
+
+### 7. Build and Verify
+
+```bash
+npm run build
+npm run test:ci
+```
+
+## Quick Reference: File Checklist
+
+For a new complement called `<Nombre>`:
+
+```
+CREATE:
+  src/4.0/<nombre>/
+    <Nombre>.ts              # Main class extending Complemento<T>
+    index.ts                 # Barrel export
+    type/
+      <nombre>.xslt.ts      # XML interfaces (Xml*, Xml*Attributes)
+      <nombre>.enum.ts       # Enums (if SAT defines catalogs)
+      index.ts               # Type barrel export
+
+UPDATE:
+  src/index.ts                                    # Add export
+  src/types/tags/complements.interface.ts          # Add to:
+    - XmlComplements or XmlComplementsConcepts     #   interface mapping
+    - ComlementType                                #   class union
+    - ComplementTypeXml<T>                         #   XML type union
+    - XmlComplementsAttributes                     #   xmlns declaration
+    - XmlnsComplementsLinks                        #   namespace links
+
+CREATE (optional):
+  test/<nombre>.test.ts                            # Vitest tests
+```
+
+## Common Pitfalls
+
+- **Forgetting to register in `complements.interface.ts`**: The complement will work in isolation but won't be recognized by the CFDI builder. This is the most commonly missed step.
+- **Wrong namespace prefix in key**: The part before the colon in `key` must match the namespace prefix used in the XML interfaces (e.g., `'aerolineas:Aerolineas'` uses prefix `aerolineas`).
+- **XSD URL mismatch**: Double-check the XSD URL against the SAT's official site. A wrong URL means validation will fail.
+- **Missing `_attributes` property**: Every XML element interface needs `_attributes` — this is how `xml-js` represents XML attributes.
+- **Not re-exporting from index.ts**: Both the complement directory and the main `src/index.ts` need export lines.
+- **"Fixing" the ComlementType typo**: It's `ComlementType` not `ComplementType` throughout the codebase. Don't rename it.
+
+## Reference: Existing Complement Examples
+
+Read these files to see the patterns in action:
+
+- **Simple**: `src/4.0/iedu/Iedu.ts` — flat attributes, extends Complemento
+- **With children**: `src/4.0/aerolineas/Aerolineas.ts` — nested elements, builder methods
+- **Complex**: `src/4.0/cartaporte20/CartaPorte20.ts` — multiple nested helpers, setter methods
+- **Concept-level**: `src/4.0/iedu/Iedu.ts` — attaches to individual concepts, not root

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,19 +54,33 @@ jobs:
         if: steps.branch.outputs.is_main == 'true'
         run: |
           SCOPES='${{ steps.cfdi.outputs.scopes }}'
+          TOTAL=$(echo "$SCOPES" | jq -r '.[]' | wc -l | tr -d ' ')
+          PUBLISHED=0
+          FAILED_COUNT=0
           FAILED=""
           for scope in $(echo "$SCOPES" | jq -r '.[]'); do
             echo "=== Publishing $scope ==="
             rush version --version-policy "$scope" --bump
             if rush publish -p -b main --version-policy "$scope" --include-all --set-access-level=public; then
               git add -A
+              PUBLISHED=$((PUBLISHED + 1))
               echo "✓ $scope published"
             else
+              FAILED_COUNT=$((FAILED_COUNT + 1))
               FAILED="$FAILED $scope"
               git checkout -- .
               echo "::warning::✗ $scope failed, reverted"
             fi
           done
+          echo ""
+          echo "========== PUBLISH SUMMARY =========="
+          echo "Total scopes: $TOTAL"
+          echo "Published:    $PUBLISHED"
+          echo "Failed:       $FAILED_COUNT"
+          if [ -n "$FAILED" ]; then
+            echo "Failed list: $FAILED"
+          fi
+          echo "====================================="
           if [ -n "$FAILED" ]; then
             echo "::error::Failed scopes:$FAILED"
             exit 1
@@ -77,19 +91,33 @@ jobs:
         run: |
           TAG="${{ steps.branch.outputs.name }}"
           SCOPES='${{ steps.cfdi.outputs.scopes }}'
+          TOTAL=$(echo "$SCOPES" | jq -r '.[]' | wc -l | tr -d ' ')
+          PUBLISHED=0
+          FAILED_COUNT=0
           FAILED=""
           for scope in $(echo "$SCOPES" | jq -r '.[]'); do
             echo "=== Publishing $scope ==="
             rush version --version-policy "$scope" --bump --override-bump prerelease --override-prerelease-id "$TAG"
-            if rush publish --publish --version-policy "$scope" --tag "$TAG" --include-all --set-access-level=public --apply; then
+            if rush publish --publish --version-policy "$scope" --tag "$TAG" --include-all --set-access-level=public; then
               git add -A
+              PUBLISHED=$((PUBLISHED + 1))
               echo "✓ $scope published"
             else
+              FAILED_COUNT=$((FAILED_COUNT + 1))
               FAILED="$FAILED $scope"
               git checkout -- .
               echo "::warning::✗ $scope failed, reverted"
             fi
           done
+          echo ""
+          echo "========== PUBLISH SUMMARY =========="
+          echo "Total scopes: $TOTAL"
+          echo "Published:    $PUBLISHED"
+          echo "Failed:       $FAILED_COUNT"
+          if [ -n "$FAILED" ]; then
+            echo "Failed list: $FAILED"
+          fi
+          echo "====================================="
           if [ -n "$FAILED" ]; then
             echo "::error::Failed scopes:$FAILED"
             exit 1
@@ -98,6 +126,7 @@ jobs:
       - name: Commit version bumps
         run: |
           BRANCH="${{ steps.branch.outputs.name }}"
+          git add -A
           if [ -n "$(git diff --cached --name-only)" ]; then
             if [ "$BRANCH" = "main" ]; then
               git commit -m "chore: release $(date +%Y-%m-%d)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
           for scope in $(echo "$SCOPES" | jq -r '.[]'); do
             echo "=== Publishing $scope ==="
             rush version --version-policy "$scope" --bump --override-bump prerelease --override-prerelease-id "$TAG"
-            if rush publish --publish --version-policy "$scope" --tag "$TAG" --include-all --set-access-level=public; then
+            if rush publish --publish --version-policy "$scope" --tag "$TAG" --include-all --set-access-level=public --apply; then
               git add -A
               PUBLISHED=$((PUBLISHED + 1))
               echo "✓ $scope published"

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -31,52 +31,24 @@
       "allowedCategories": [ "libraries", "private" ]
     },
     {
+      "name": "@cfdi/cancelacion",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@cfdi/catalogos",
       "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@cfdi/complementos",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@cfdi/csd",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@cfdi/csf",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@renapo/curp",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@sat/auth",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@sat/recursos",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@sat/scraper",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@sat/opinion",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@sat/contabilidad",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@sat/captcha",
-      "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "@cfdi/cancelacion",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@cfdi/designs",
@@ -84,7 +56,11 @@
     },
     {
       "name": "@cfdi/elements",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "private" ]
+    },
+    {
+      "name": "@cfdi/expresiones",
+      "allowedCategories": [ "private" ]
     },
     {
       "name": "@cfdi/openssl",
@@ -95,12 +71,20 @@
       "allowedCategories": [ "libraries", "private" ]
     },
     {
+      "name": "@cfdi/rfc",
+      "allowedCategories": [ "private" ]
+    },
+    {
       "name": "@cfdi/schema",
       "allowedCategories": [ "libraries", "private" ]
     },
     {
+      "name": "@cfdi/transform",
+      "allowedCategories": [ "private" ]
+    },
+    {
       "name": "@cfdi/types",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@cfdi/utils",
@@ -108,7 +92,7 @@
     },
     {
       "name": "@cfdi/xml",
-      "allowedCategories": [ "libraries", "production" ]
+      "allowedCategories": [ "libraries", "private", "production" ]
     },
     {
       "name": "@cfdi/xml2json",
@@ -116,11 +100,11 @@
     },
     {
       "name": "@cfdi/xsd",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@clir/openssl",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@emotion/cache",
@@ -271,6 +255,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "@renapo/curp",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@rollup/plugin-terser",
       "allowedCategories": [ "libraries" ]
     },
@@ -291,8 +279,32 @@
       "allowedCategories": [ "libraries", "production" ]
     },
     {
-      "name": "@saxon-he/cli",
+      "name": "@sat/auth",
       "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@sat/captcha",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@sat/contabilidad",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@sat/opinion",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@sat/recursos",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@sat/scraper",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
+      "name": "@saxon-he/cli",
+      "allowedCategories": [ "libraries", "private" ]
     },
     {
       "name": "@size-limit/preset-small-lib",

--- a/packages/cfdi/catalogos/package.json
+++ b/packages/cfdi/catalogos/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/catalogos",
   "version": "4.0.16-dev.2",
+  "description": "Catalogos oficiales del SAT para CFDI 4.0 como enums TypeScript",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -30,7 +35,20 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui"
   },
-  "author": "MisaelMa",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "keywords": [
+    "cfdi", "sat", "catalogos", "enums", "forma pago", "metodo pago",
+    "uso cfdi", "regimen fiscal", "moneda", "factura electronica",
+    "mexico", "cfdi 4.0", "node", "typescript"
+  ],
+  "author": {
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  },
   "devDependencies": {
     "@recreando/vite": "workspace:*",
     "@recreando/eslint-settings": "workspace:*",

--- a/packages/cfdi/complementos/package.json
+++ b/packages/cfdi/complementos/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@cfdi/complementos",
   "version": "4.0.17-dev.2",
-  "description": "Libreria para generar complementos del cfdi V4.0",
+  "description": "Complementos fiscales del SAT para CFDI 4.0: pagos, nomina, comercio exterior, carta porte",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "homepage": "https://cfdi.recreando.dev",
   "license": "MIT",
   "main": "./dist/index.cjs",
@@ -53,43 +56,13 @@
     "@vitest/ui": "2.1.3"
   },
   "keywords": [
-    "CFDI 3.3.",
-    "Factura Electronica",
-    "Factura Electronica Mexico",
-    "Sellar Xml",
-    "SAT",
-    "Buzon tributario",
-    "cfdiv33",
-    "cfdi",
-    "sat",
-    "3.3",
-    "factura",
-    "mexico",
-    "pdf",
-    "complemento",
-    "timbre",
-    "iedu",
-    "nomina",
-    "exterior",
-    "terceros",
-    "pagos",
-    "ine"
+    "cfdi", "sat", "complemento", "pagos", "nomina", "comercio exterior",
+    "carta porte", "ine", "iedu", "factura electronica", "mexico",
+    "cfdi 4.0", "node", "typescript"
   ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
-  },
-  "contributors": [
-    {
-      "name": "Amir Misael Marin Coh",
-      "email": "amisael.amir.misae@gmail.com",
-      "url": "https://misael.signati.app/"
-    },
-    {
-      "name": "Jose Alberto Marin Coh",
-      "email": "",
-      "url": ""
-    }
-  ]
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  }
 }

--- a/packages/cfdi/csd/package.json
+++ b/packages/cfdi/csd/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/csd",
   "version": "4.0.16-dev.2",
+  "description": "Certificados de Sello Digital (CSD) - lectura de archivos .cer y .key para CFDI",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -23,7 +28,19 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui"
   },
-  "author": "MisaelMa",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "keywords": [
+    "cfdi", "sat", "csd", "certificado", "sello digital", "cer", "key",
+    "firma", "fiel", "factura electronica", "mexico", "node", "typescript"
+  ],
+  "author": {
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  },
   "dependencies": {
     "@clir/openssl": "workspace:*",
     "moment": "^2.29.4",

--- a/packages/cfdi/csf/package.json
+++ b/packages/cfdi/csf/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/csf",
   "version": "4.0.16-dev.2",
+  "description": "Lectura y parseo de Constancia de Situacion Fiscal (CSF) del SAT",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -27,10 +32,14 @@
     "type": "git",
     "url": "git+https://github.com/MisaelMa/node-cfdi.git"
   },
+  "keywords": [
+    "cfdi", "sat", "csf", "constancia", "situacion fiscal", "rfc",
+    "factura electronica", "mexico", "node", "typescript"
+  ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
   },
   "dependencies": {
     "xml-js": "^1.6.11",

--- a/packages/cfdi/elements/package.json
+++ b/packages/cfdi/elements/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@cfdi/elements",
   "version": "4.0.14-dev.1",
-  "description": "Libreria para crear y sellar xml cfdi V4.0",
+  "description": "Elementos estructurales del comprobante CFDI 4.0: emisor, receptor, conceptos",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "homepage": "https://cfdi.recreando.dev",
   "license": "MIT",
   "main": "./dist/index.cjs",
@@ -58,43 +61,12 @@
     "@vitest/ui": "2.1.3"
   },
   "keywords": [
-    "CFDI 3.3.",
-    "Factura Electronica",
-    "Factura Electronica Mexico",
-    "Sellar Xml",
-    "SAT",
-    "Buzon tributario",
-    "cfdiv33",
-    "cfdi",
-    "sat",
-    "3.3",
-    "factura",
-    "mexico",
-    "pdf",
-    "complemento",
-    "timbre",
-    "iedu",
-    "nomina",
-    "exterior",
-    "terceros",
-    "pagos",
-    "ine"
+    "cfdi", "sat", "elementos", "comprobante", "emisor", "receptor",
+    "conceptos", "cfdi 4.0", "factura electronica", "mexico", "node", "typescript"
   ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
-  },
-  "contributors": [
-    {
-      "name": "Amir Misael Marin Coh",
-      "email": "amisael.amir.misae@gmail.com",
-      "url": "https://cfdi.recreando.dev"
-    },
-    {
-      "name": "Jose Alberto Marin Coh",
-      "email": "",
-      "url": ""
-    }
-  ]
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  }
 }

--- a/packages/cfdi/expresiones/package.json
+++ b/packages/cfdi/expresiones/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/expresiones",
   "version": "4.0.14-dev.1",
+  "description": "Generacion de expresiones impresas (codigo QR) para CFDI",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -50,9 +55,13 @@
     "@vitest/coverage-v8": "2.1.3",
     "@vitest/ui": "2.1.3"
   },
+  "keywords": [
+    "cfdi", "sat", "qr", "expresion impresa", "codigo qr",
+    "factura electronica", "mexico", "cfdi 4.0", "node", "typescript"
+  ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
   }
 }

--- a/packages/cfdi/rfc/package.json
+++ b/packages/cfdi/rfc/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/rfc",
   "version": "0.0.10-dev.1",
+  "description": "Validacion de RFC mexicano - persona fisica y moral con digito verificador",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -23,7 +28,19 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui"
   },
-  "author": "MisaelMa",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "keywords": [
+    "cfdi", "sat", "rfc", "validacion", "persona fisica", "persona moral",
+    "digito verificador", "mexico", "node", "typescript"
+  ],
+  "author": {
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  },
   "devDependencies": {
     "@recreando/eslint-settings": "workspace:*",
     "@recreando/vite": "workspace:*",

--- a/packages/cfdi/transform/package.json
+++ b/packages/cfdi/transform/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/transform",
   "version": "4.0.14-dev.1",
+  "description": "Transformacion XSLT para generacion de cadena original de CFDI",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -34,10 +39,14 @@
     "type": "git",
     "url": "git+https://github.com/MisaelMa/node-cfdi.git"
   },
+  "keywords": [
+    "cfdi", "sat", "xslt", "cadena original", "transformacion",
+    "factura electronica", "mexico", "cfdi 4.0", "node", "typescript"
+  ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
   },
   "dependencies": {
     "xml-js": "^1.6.11"

--- a/packages/cfdi/types/package.json
+++ b/packages/cfdi/types/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@cfdi/types",
   "version": "4.0.14-dev.1",
-  "description": "Libreria para crear y sellar xml cfdi V4.0",
+  "description": "Interfaces y tipos TypeScript para CFDI 4.0 del SAT",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "homepage": "https://cfdi.recreando.dev",
   "license": "MIT",
   "main": "./dist/index.cjs",
@@ -58,43 +61,12 @@
     "@vitest/ui": "2.1.3"
   },
   "keywords": [
-    "CFDI 3.3.",
-    "Factura Electronica",
-    "Factura Electronica Mexico",
-    "Sellar Xml",
-    "SAT",
-    "Buzon tributario",
-    "cfdiv33",
-    "cfdi",
-    "sat",
-    "3.3",
-    "factura",
-    "mexico",
-    "pdf",
-    "complemento",
-    "timbre",
-    "iedu",
-    "nomina",
-    "exterior",
-    "terceros",
-    "pagos",
-    "ine"
+    "cfdi", "sat", "types", "interfaces", "typescript", "tipado",
+    "cfdi 4.0", "factura electronica", "mexico", "node"
   ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
-  },
-  "contributors": [
-    {
-      "name": "Amir Misael Marin Coh",
-      "email": "amisael.amir.misae@gmail.com",
-      "url": "https://cfdi.recreando.dev"
-    },
-    {
-      "name": "Jose Alberto Marin Coh",
-      "email": "",
-      "url": ""
-    }
-  ]
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  }
 }

--- a/packages/cfdi/utils/package.json
+++ b/packages/cfdi/utils/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/utils",
   "version": "4.0.17-dev.1",
+  "description": "Utilidades para CFDI: conversion de numeros a letras, formateo de montos",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -43,9 +48,13 @@
     "type": "git",
     "url": "git+https://github.com/MisaelMa/node-cfdi.git"
   },
+  "keywords": [
+    "cfdi", "sat", "utilidades", "numero a letras", "monto",
+    "factura electronica", "mexico", "node", "typescript"
+  ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
   }
 }

--- a/packages/cfdi/xml/package.json
+++ b/packages/cfdi/xml/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@cfdi/xml",
   "version": "4.0.18-dev.2",
-  "description": "Libreria para crear y sellar xml cfdi V4.0",
+  "description": "Generacion, sellado y timbrado de XML CFDI 4.0 para Node.js - facturacion electronica Mexico",
   "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -58,47 +61,13 @@
     "@vitest/ui": "2.1.3"
   },
   "keywords": [
-    "CFDI 3.3.",
-    "CFDI 4.0.",
-    "Factura Electronica",
-    "Factura Electronica Mexico",
-    "Sellar Xml",
-    "SAT",
-    "Buzon tributario",
-    "cfdiv33",
-    "cfdi",
-    "sat",
-    "3.3",
-    "4.0",
-    "factura",
-    "mexico",
-    "pdf",
-    "complemento",
-    "timbre",
-    "iedu",
-    "nomina",
-    "exterior",
-    "terceros",
-    "pagos",
-    "ine",
-    "transform",
-    "sello"
+    "cfdi", "sat", "xml", "factura", "factura electronica", "facturacion",
+    "mexico", "comprobante fiscal", "cfdi 4.0", "anexo 20", "sello",
+    "timbrado", "cadena original", "certificado", "node", "typescript"
   ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
-  },
-  "contributors": [
-    {
-      "name": "Amir Misael Marin Coh",
-      "email": "amisael.amir.misae@gmail.com",
-      "url": "https://cfdi.recreando.dev"
-    },
-    {
-      "name": "Jose Alberto Marin Coh",
-      "email": "",
-      "url": ""
-    }
-  ]
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  }
 }

--- a/packages/cfdi/xml2json/package.json
+++ b/packages/cfdi/xml2json/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/2json",
   "version": "4.0.14-dev.1",
+  "description": "Conversion de XML CFDI a JSON para Node.js",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -34,10 +39,14 @@
     "type": "git",
     "url": "git+https://github.com/MisaelMa/node-cfdi.git"
   },
+  "keywords": [
+    "cfdi", "sat", "xml", "json", "parser", "conversion",
+    "factura electronica", "mexico", "node", "typescript"
+  ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
   },
   "dependencies": {
     "xml-js": "^1.6.11",

--- a/packages/cfdi/xsd/package.json
+++ b/packages/cfdi/xsd/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cfdi/xsd",
   "version": "4.0.17-dev.2",
+  "description": "Validacion de CFDI contra esquemas XSD oficiales del SAT",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -34,10 +39,14 @@
     "type": "git",
     "url": "git+https://github.com/MisaelMa/node-cfdi.git"
   },
+  "keywords": [
+    "cfdi", "sat", "xsd", "validacion", "esquema", "schema", "xml",
+    "factura electronica", "mexico", "cfdi 4.0", "node", "typescript"
+  ],
   "author": {
-    "name": "Amir Misael Marin Coh, Signati",
-    "email": "amisael.amir.misae@gmail.com, signatidev@gmail.com,",
-    "url": ""
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
   },
   "dependencies": {
     "xml-js": "^1.6.11",

--- a/packages/clir/openssl/package.json
+++ b/packages/clir/openssl/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@clir/openssl",
   "version": "0.0.17-dev.1",
+  "description": "Wrapper de OpenSSL CLI para certificados digitales del SAT",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -23,7 +28,19 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui"
   },
-  "author": "MisaelMa",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "keywords": [
+    "cfdi", "sat", "openssl", "cli", "certificado", "firma digital",
+    "csd", "fiel", "mexico", "node", "typescript"
+  ],
+  "author": {
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  },
   "dependencies": {
     "node-forge": "^1.3.1",
     "@esm2cjs/execa": "^6.1.1-cjs.1"

--- a/packages/clir/saxon-he/package.json
+++ b/packages/clir/saxon-he/package.json
@@ -1,5 +1,10 @@
 {
   "version": "12.5.2-dev.1",
+  "description": "Wrapper de Saxon-HE para transformaciones XSLT en Node.js",
+  "homepage": "https://cfdi.recreando.dev",
+  "bugs": {
+    "url": "https://github.com/MisaelMa/node-cfdi/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -23,7 +28,19 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui"
   },
-  "author": "MisaelMa",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "keywords": [
+    "saxon", "xslt", "transformacion", "cadena original", "cfdi", "sat",
+    "java", "cli", "node", "typescript"
+  ],
+  "author": {
+    "name": "Amir Misael Marin Coh",
+    "email": "amisael.amir.misael@gmail.com",
+    "url": "https://recreando.dev"
+  },
   "dependencies": {
     "@esm2cjs/execa": "^6.1.1-cjs.1"
   },

--- a/packages/test-cjs/package-lock.json
+++ b/packages/test-cjs/package-lock.json
@@ -1,0 +1,643 @@
+{
+  "name": "test-cjs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-cjs",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cfdi/2json": "4.0.13",
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.16",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/csf": "4.0.15",
+        "@cfdi/elements": "4.0.13",
+        "@cfdi/expresiones": "4.0.13",
+        "@cfdi/rfc": "0.0.10",
+        "@cfdi/transform": "4.0.13",
+        "@cfdi/types": "4.0.13",
+        "@cfdi/utils": "4.0.16",
+        "@cfdi/xml": "4.0.17",
+        "@cfdi/xsd": "4.0.16",
+        "@clir/openssl": "0.0.16",
+        "@saxon-he/cli": "12.5.1"
+      }
+    },
+    "node_modules/@cfdi/2json": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/2json/-/2json-4.0.13.tgz",
+      "integrity": "sha512-Z4pKLkAmHc5q0hmiwxqRomMIn/Y7Vo0MnJDYni/tkl1t8v6omCVYYEoOVEDfYeTY8n5p7txjgKjM27xwSlje4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/elements": "4.0.13",
+        "@cfdi/types": "4.0.13",
+        "@cfdi/utils": "4.0.16",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/catalogos": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/catalogos/-/catalogos-4.0.15.tgz",
+      "integrity": "sha512-C+b6RXsfJpj2enU7Vgk3HMhFwSGaj/lMYwBoa1JieMOtgehE/6JOrC/WAcV8lBz+603Be7DqqZZMZoLBbu8Nkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/complementos": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cfdi/complementos/-/complementos-4.0.16.tgz",
+      "integrity": "sha512-C4JdkH2TokhwWj5FxTQ7sZ8bsfsXo70OvSWGe+GdeqxEF7GnGieGvU2nrOI20HQMnv6r20HOUKEEceo5YZaNVw==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/csd": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/csd/-/csd-4.0.15.tgz",
+      "integrity": "sha512-k4bfZujdhmBeL8FeJ9svp2j+qpbWd8hAQSy4fku0004cUysaUjC6yq29wAQnBE+RX6H6ai9z4fitOOyIxvhvqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clir/openssl": "0.0.16",
+        "curp": "^1.2.0",
+        "moment": "^2.29.4",
+        "node-forge": "^1.3.1",
+        "validate-rfc": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/csf": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/csf/-/csf-4.0.15.tgz",
+      "integrity": "sha512-5lhlGdojtAnEQ9Fsss70VijIjd5ytbZCDiCiRMBZq/vsIlG2IHTN7+Ts46vU04/g8wTv23+WyPkEvs9agqH1Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "pdf-parse": "^1.1.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/elements": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/elements/-/elements-4.0.13.tgz",
+      "integrity": "sha512-2jVPPnTqu407KcWIExnXabGQNpoNn4qT+QDBIWtYX6q611wPGVA6KZjTNhPpDWURufatHMdm689t09HEHKSQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.15",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/xsd": "4.0.15",
+        "@saxon-he/cli": "12.5.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/elements/node_modules/@cfdi/complementos": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/complementos/-/complementos-4.0.15.tgz",
+      "integrity": "sha512-1wOgCoRfLwPuSEql/xhiUX8g9XqKh2LowXWRdop8Bxlxm2bW+zaOmMMr92htMOpl0q9d/vlCVIweilV9NYozdg==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/elements/node_modules/@cfdi/xsd": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/xsd/-/xsd-4.0.15.tgz",
+      "integrity": "sha512-AzRdA8tiDptTPfX9CzpVEcD6mwaVSd06Jhex7xoB1nuG+E9IayHrAtFEy1dmwtjOVRIYBA3VfXj5VqBtm2c2rw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "xml-js": "^1.6.11",
+        "xslt": "^0.9.1",
+        "xslt-processor": "^0.11.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/expresiones": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/expresiones/-/expresiones-4.0.13.tgz",
+      "integrity": "sha512-4Wqb8ii7q6igRhjVzPBijPXaOfp24LgOL6lfS7wwvZkN6a+IUd1/30/FPnqvCUUFwR9RzjgW7uBv9bx06oL5IA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/rfc": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@cfdi/rfc/-/rfc-0.0.10.tgz",
+      "integrity": "sha512-zGgjewfrLfmda5qL8J1rRUbJvP/dqhn5ymxVY4anaY+4UJyUYD/eDYoUjd43NPcqPROlGY8K5q6hv80qc7Ts5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/transform": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/transform/-/transform-4.0.13.tgz",
+      "integrity": "sha512-VcyO9W9mJ80w51xcg/Eyg/M3Wnkand2db34t/KFN/XyhXaLBuGosNS2Nd1xriWAWEpX+wUwU4PI/Wf84kP1L5A==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/types": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/types/-/types-4.0.13.tgz",
+      "integrity": "sha512-bXIXlkmZfWyGfR+EQpVejcwztE4yBfmeDURuW4c+89qjoNkBTogZ8Prggoup9IQOdAzdFOtRY1Thj9JIqigfNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.15",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/xsd": "4.0.15",
+        "@saxon-he/cli": "12.5.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/types/node_modules/@cfdi/complementos": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/complementos/-/complementos-4.0.15.tgz",
+      "integrity": "sha512-1wOgCoRfLwPuSEql/xhiUX8g9XqKh2LowXWRdop8Bxlxm2bW+zaOmMMr92htMOpl0q9d/vlCVIweilV9NYozdg==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/types/node_modules/@cfdi/xsd": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/xsd/-/xsd-4.0.15.tgz",
+      "integrity": "sha512-AzRdA8tiDptTPfX9CzpVEcD6mwaVSd06Jhex7xoB1nuG+E9IayHrAtFEy1dmwtjOVRIYBA3VfXj5VqBtm2c2rw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "xml-js": "^1.6.11",
+        "xslt": "^0.9.1",
+        "xslt-processor": "^0.11.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/utils": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cfdi/utils/-/utils-4.0.16.tgz",
+      "integrity": "sha512-QYbDGK7AJcEKyZeJDiqjpt+egFuuW/5ckRp3WSznF9I3VojwbvlL2GI/3nBazRLCHYZxSMZkmm2ErEqkgI05Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/xml": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@cfdi/xml/-/xml-4.0.17.tgz",
+      "integrity": "sha512-/09ILXndVQolwluwK39uPe6jr1SFVwQToxH2BAcmhONP3BYsd0ryV9nDjNn0yclZWaiP8o7712DJFkjlXRvYLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.16",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/xsd": "4.0.16",
+        "@saxon-he/cli": "12.5.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/xsd": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cfdi/xsd/-/xsd-4.0.16.tgz",
+      "integrity": "sha512-hi12PuGAGWEm6md5YG8ChleUipj3mYrsUVnD7Seuw/2zXeopwcRiW7F8M4oBE1qImuto+CbHzuCq6qN5ZTy9EA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "xml-js": "^1.6.11",
+        "xslt": "^0.9.1",
+        "xslt-processor": "^0.11.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@clir/openssl": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@clir/openssl/-/openssl-0.0.16.tgz",
+      "integrity": "sha512-LgXVIW0aLctlwJWxw6NAhNnzPNZfR0PUqXnsRb3KV/dALqI4M0GpPhwovnYN4eoy0VtWAK0BjM40greyjGVWxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/execa": "^6.1.1-cjs.1",
+        "moment": "^2.29.4",
+        "node-forge": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@esm2cjs/execa": {
+      "version": "6.1.1-cjs.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/execa/-/execa-6.1.1-cjs.1.tgz",
+      "integrity": "sha512-FHxfnmuDIjY1VS/BLzDkL8EkbcFvi8s6x1nYQ1Nyu0An0n88EJcGhDBcRWLFwt3C3nT7xwI+MwHRH1TZcAFW2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/human-signals": "^3.0.1",
+        "@esm2cjs/is-stream": "^3.0.0",
+        "@esm2cjs/npm-run-path": "^5.1.1-cjs.0",
+        "@esm2cjs/onetime": "^6.0.1-cjs.0",
+        "@esm2cjs/strip-final-newline": "^3.0.1-cjs.0",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "merge-stream": "^2.0.0",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-QZme4eF/PwTpeSbMB4AaWGQ4VSygzE30jI+Oas1NPTtZQAgcHwWVDOQpIW8FUmtzn5Q+2cS7AjnTzbtqtc5P6g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-qcBscHlJpZFOD5nnmMHkzOrq2xyvsp9fbVreQLS8x2LOs8N3CrNi3fqvFY0GVJR+YSOHscwhG9T5t4Ck7R7QGw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-LIIAjcpjLr4rcbYmRQ+eRu55Upy/MMB78seIlwqbnyiA+cTa1/pxWnJ1NHJQrw6tx2wMQmlYoJj+wf16NjWH6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/npm-run-path": {
+      "version": "5.1.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/npm-run-path/-/npm-run-path-5.1.1-cjs.0.tgz",
+      "integrity": "sha512-CWeAIyE8iNSCgP2ItPE8iPgS+lACqgH+MuFRaWOIl2T7hnHqPFfhAJJ/LcLJJ/RMIxNMeenjFMwc91HW7NWr1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/onetime": {
+      "version": "6.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/onetime/-/onetime-6.0.1-cjs.0.tgz",
+      "integrity": "sha512-MkZMZSxrSC/6yUuAw6Azc56XOgwHQQIsNDlO/zgFmOcycJBhRwRuc/gdYUUOFNZIh7y+f0JSIxkNdJPFvJ5W0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-fKzZ3uIIP4j+7WfyG0MEkomGHL0hUXWCx1kY2Zct3GTdl4pyY+3k5lCUxjgdDa2Ld1BCjMNorXnRHiBP6jW6CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/strip-final-newline": {
+      "version": "3.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/strip-final-newline/-/strip-final-newline-3.0.1-cjs.0.tgz",
+      "integrity": "sha512-o41riCGPiOEStayoikBCAqwa6igbv9L9rP+k5UCfQ24EJD/wGrdDs/KTNwkHG5JzDK3T60D5dMkWkLKEPy8gjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@saxon-he/cli": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@saxon-he/cli/-/cli-12.5.1.tgz",
+      "integrity": "sha512-j4wZxRVlpe0v//nGMPctiW/ZQmgp1I51pOWsjZmgwzrA8Fc7gQhARI6rZojmb+ne3iWudseq896dVc1HsHqTCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/execa": "^6.1.1-cjs.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/curp": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/curp/-/curp-1.3.1.tgz",
+      "integrity": "sha512-DoUGrXK7qe6qnSgumTGa9yULrMJy/1Npsgt0LkGkjWXfL/xVyJPcAQgyEJpNaJQjOlCvdEZWJ2K9vNlTmYrHHw==",
+      "license": "GPL-3.0",
+      "engines": {
+        "npm": ">= 8.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/validate-rfc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/validate-rfc/-/validate-rfc-2.0.3.tgz",
+      "integrity": "sha512-WS7CyAz/sfzx6DryOPZvprqz7uxHcQh1yhzDunNX1vidSmprfN7Og66VRpCyU21U82Vzkof5/bOIOKan3dEXLA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xslt": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/xslt/-/xslt-0.9.1.tgz",
+      "integrity": "sha512-2eFkaiFRVkVzedBKYv3MUYmvvK9103NTNFGsyFhLim0Pad0q5yXp2j9tQM2lFW1gFr9fSXV70RRrdcRM7YdRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.33"
+      }
+    },
+    "node_modules/xslt-processor": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/xslt-processor/-/xslt-processor-0.11.7.tgz",
+      "integrity": "sha512-66vcLzwSP4dAvzm4O+Lq20Su03ckrGaYn1kbdCNDp9HaaBZgHJJNZlrVSkvfEuKNvqd4wk9XGU5Rvi+eUJqf+w==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "he": "^1.2.0"
+      }
+    }
+  }
+}

--- a/packages/test-cjs/package.json
+++ b/packages/test-cjs/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "test-cjs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.cjs",
+    "update-versions": "node update-versions.mjs"
+  },
+  "dependencies": {
+    "@cfdi/xml": "4.0.17",
+    "@cfdi/complementos": "4.0.16",
+    "@cfdi/xsd": "4.0.16",
+    "@cfdi/csd": "4.0.15",
+    "@cfdi/csf": "4.0.15",
+    "@cfdi/catalogos": "4.0.15",
+    "@cfdi/utils": "4.0.16",
+    "@cfdi/rfc": "0.0.10",
+    "@cfdi/types": "4.0.13",
+    "@cfdi/transform": "4.0.13",
+    "@cfdi/2json": "4.0.13",
+    "@cfdi/expresiones": "4.0.13",
+    "@cfdi/elements": "4.0.13",
+    "@clir/openssl": "0.0.16",
+    "@saxon-he/cli": "12.5.1"
+  }
+}

--- a/packages/test-cjs/routes/cfdi-2json.cjs
+++ b/packages/test-cjs/routes/cfdi-2json.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/2json',
+  name: '@cfdi/2json',
+  test() {
+    const pkg = require('@cfdi/2json');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-catalogos.cjs
+++ b/packages/test-cjs/routes/cfdi-catalogos.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/catalogos',
+  name: '@cfdi/catalogos',
+  test() {
+    const pkg = require('@cfdi/catalogos');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-complementos.cjs
+++ b/packages/test-cjs/routes/cfdi-complementos.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/complementos',
+  name: '@cfdi/complementos',
+  test() {
+    const pkg = require('@cfdi/complementos');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-csd.cjs
+++ b/packages/test-cjs/routes/cfdi-csd.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/csd',
+  name: '@cfdi/csd',
+  test() {
+    const pkg = require('@cfdi/csd');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-csf.cjs
+++ b/packages/test-cjs/routes/cfdi-csf.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/csf',
+  name: '@cfdi/csf',
+  test() {
+    const pkg = require('@cfdi/csf');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-elements.cjs
+++ b/packages/test-cjs/routes/cfdi-elements.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/elements',
+  name: '@cfdi/elements',
+  test() {
+    const pkg = require('@cfdi/elements');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-expresiones.cjs
+++ b/packages/test-cjs/routes/cfdi-expresiones.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/expresiones',
+  name: '@cfdi/expresiones',
+  test() {
+    const pkg = require('@cfdi/expresiones');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-rfc.cjs
+++ b/packages/test-cjs/routes/cfdi-rfc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/rfc',
+  name: '@cfdi/rfc',
+  test() {
+    const pkg = require('@cfdi/rfc');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-transform.cjs
+++ b/packages/test-cjs/routes/cfdi-transform.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/transform',
+  name: '@cfdi/transform',
+  test() {
+    const pkg = require('@cfdi/transform');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-types.cjs
+++ b/packages/test-cjs/routes/cfdi-types.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/types',
+  name: '@cfdi/types',
+  test() {
+    const pkg = require('@cfdi/types');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-utils.cjs
+++ b/packages/test-cjs/routes/cfdi-utils.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/utils',
+  name: '@cfdi/utils',
+  test() {
+    const pkg = require('@cfdi/utils');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-xml.cjs
+++ b/packages/test-cjs/routes/cfdi-xml.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/xml',
+  name: '@cfdi/xml',
+  test() {
+    const pkg = require('@cfdi/xml');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/cfdi-xsd.cjs
+++ b/packages/test-cjs/routes/cfdi-xsd.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@cfdi/xsd',
+  name: '@cfdi/xsd',
+  test() {
+    const pkg = require('@cfdi/xsd');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/clir-openssl.cjs
+++ b/packages/test-cjs/routes/clir-openssl.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@clir/openssl',
+  name: '@clir/openssl',
+  test() {
+    const pkg = require('@clir/openssl');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/routes/saxon-he-cli.cjs
+++ b/packages/test-cjs/routes/saxon-he-cli.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/@saxon-he/cli',
+  name: '@saxon-he/cli',
+  test() {
+    const pkg = require('@saxon-he/cli');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-cjs/server.cjs
+++ b/packages/test-cjs/server.cjs
@@ -1,0 +1,88 @@
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PORT = process.env.PORT || 3001;
+const routesDir = path.join(__dirname, 'routes');
+
+function loadRoutes() {
+  const routes = {};
+  const files = fs.readdirSync(routesDir).filter(f => f.endsWith('.cjs'));
+
+  for (const file of files) {
+    const route = require(path.join(routesDir, file));
+    routes[route.path] = route;
+  }
+
+  return routes;
+}
+
+function json(res, data, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data, null, 2));
+}
+
+const routes = loadRoutes();
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const pathname = url.pathname;
+
+  if (pathname === '/') {
+    const available = Object.values(routes).map(r => ({
+      name: r.name,
+      path: r.path,
+    }));
+    return json(res, {
+      type: 'cjs',
+      routes: available,
+      endpoints: {
+        '/': 'Lista de rutas',
+        '/all': 'Ejecutar todas las rutas',
+        '/@scope/pkg': 'Ruta individual',
+      },
+    });
+  }
+
+  if (pathname === '/all') {
+    const results = [];
+    let ok = 0;
+    let failed = 0;
+
+    for (const route of Object.values(routes)) {
+      try {
+        const result = await route.test();
+        results.push({ name: route.name, status: 'ok', ...result });
+        ok++;
+      } catch (err) {
+        results.push({ name: route.name, status: 'error', message: err.message });
+        failed++;
+      }
+    }
+
+    return json(res, {
+      type: 'cjs',
+      timestamp: new Date().toISOString(),
+      summary: { total: results.length, ok, failed },
+      results,
+    });
+  }
+
+  const route = routes[pathname];
+  if (route) {
+    try {
+      const result = await route.test();
+      return json(res, { name: route.name, status: 'ok', ...result });
+    } catch (err) {
+      return json(res, { name: route.name, status: 'error', message: err.message }, 500);
+    }
+  }
+
+  json(res, { error: 'Not found', available: Object.keys(routes) }, 404);
+});
+
+server.listen(PORT, () => {
+  console.log(`[CJS] Server running on http://localhost:${PORT}`);
+  console.log(`Routes loaded: ${Object.keys(routes).length}`);
+  Object.keys(routes).forEach(r => console.log(`  ${r}`));
+});

--- a/packages/test-cjs/update-versions.mjs
+++ b/packages/test-cjs/update-versions.mjs
@@ -1,0 +1,45 @@
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rushJsonPath = resolve(__dirname, '../../rush.json');
+const pkgJsonPath = resolve(__dirname, 'package.json');
+
+const rush = JSON.parse(readFileSync(rushJsonPath, 'utf-8'));
+const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+
+const publishable = rush.projects
+  .filter(p => p.shouldPublish)
+  .map(p => p.packageName);
+
+console.log(`Found ${publishable.length} publishable packages in rush.json\n`);
+
+const updated = {};
+const errors = [];
+
+for (const name of publishable) {
+  try {
+    const raw = execSync(`npm view ${name} versions --json 2>/dev/null`, {
+      encoding: 'utf-8',
+    });
+    const versions = JSON.parse(raw);
+    const arr = Array.isArray(versions) ? versions : [versions];
+    const latest = arr[arr.length - 1];
+    updated[name] = latest;
+    console.log(`  ${name}: ${latest}`);
+  } catch {
+    errors.push(name);
+    console.log(`  ${name}: NOT FOUND on npm (skipped)`);
+  }
+}
+
+pkgJson.dependencies = updated;
+writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
+
+console.log(`\nUpdated ${Object.keys(updated).length} dependencies in package.json`);
+if (errors.length) {
+  console.log(`Skipped ${errors.length}: ${errors.join(', ')}`);
+}
+console.log('\nRun "npm install" to install the updated versions.');

--- a/packages/test-esm/package-lock.json
+++ b/packages/test-esm/package-lock.json
@@ -1,0 +1,643 @@
+{
+  "name": "test-esm",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-esm",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cfdi/2json": "4.0.13",
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.16",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/csf": "4.0.15",
+        "@cfdi/elements": "4.0.13",
+        "@cfdi/expresiones": "4.0.13",
+        "@cfdi/rfc": "0.0.10",
+        "@cfdi/transform": "4.0.13",
+        "@cfdi/types": "4.0.13",
+        "@cfdi/utils": "4.0.16",
+        "@cfdi/xml": "4.0.17",
+        "@cfdi/xsd": "4.0.16",
+        "@clir/openssl": "0.0.16",
+        "@saxon-he/cli": "12.5.1"
+      }
+    },
+    "node_modules/@cfdi/2json": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/2json/-/2json-4.0.13.tgz",
+      "integrity": "sha512-Z4pKLkAmHc5q0hmiwxqRomMIn/Y7Vo0MnJDYni/tkl1t8v6omCVYYEoOVEDfYeTY8n5p7txjgKjM27xwSlje4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/elements": "4.0.13",
+        "@cfdi/types": "4.0.13",
+        "@cfdi/utils": "4.0.16",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/catalogos": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/catalogos/-/catalogos-4.0.15.tgz",
+      "integrity": "sha512-C+b6RXsfJpj2enU7Vgk3HMhFwSGaj/lMYwBoa1JieMOtgehE/6JOrC/WAcV8lBz+603Be7DqqZZMZoLBbu8Nkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/complementos": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cfdi/complementos/-/complementos-4.0.16.tgz",
+      "integrity": "sha512-C4JdkH2TokhwWj5FxTQ7sZ8bsfsXo70OvSWGe+GdeqxEF7GnGieGvU2nrOI20HQMnv6r20HOUKEEceo5YZaNVw==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/csd": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/csd/-/csd-4.0.15.tgz",
+      "integrity": "sha512-k4bfZujdhmBeL8FeJ9svp2j+qpbWd8hAQSy4fku0004cUysaUjC6yq29wAQnBE+RX6H6ai9z4fitOOyIxvhvqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clir/openssl": "0.0.16",
+        "curp": "^1.2.0",
+        "moment": "^2.29.4",
+        "node-forge": "^1.3.1",
+        "validate-rfc": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/csf": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/csf/-/csf-4.0.15.tgz",
+      "integrity": "sha512-5lhlGdojtAnEQ9Fsss70VijIjd5ytbZCDiCiRMBZq/vsIlG2IHTN7+Ts46vU04/g8wTv23+WyPkEvs9agqH1Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "pdf-parse": "^1.1.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/elements": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/elements/-/elements-4.0.13.tgz",
+      "integrity": "sha512-2jVPPnTqu407KcWIExnXabGQNpoNn4qT+QDBIWtYX6q611wPGVA6KZjTNhPpDWURufatHMdm689t09HEHKSQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.15",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/xsd": "4.0.15",
+        "@saxon-he/cli": "12.5.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/elements/node_modules/@cfdi/complementos": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/complementos/-/complementos-4.0.15.tgz",
+      "integrity": "sha512-1wOgCoRfLwPuSEql/xhiUX8g9XqKh2LowXWRdop8Bxlxm2bW+zaOmMMr92htMOpl0q9d/vlCVIweilV9NYozdg==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/elements/node_modules/@cfdi/xsd": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/xsd/-/xsd-4.0.15.tgz",
+      "integrity": "sha512-AzRdA8tiDptTPfX9CzpVEcD6mwaVSd06Jhex7xoB1nuG+E9IayHrAtFEy1dmwtjOVRIYBA3VfXj5VqBtm2c2rw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "xml-js": "^1.6.11",
+        "xslt": "^0.9.1",
+        "xslt-processor": "^0.11.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/expresiones": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/expresiones/-/expresiones-4.0.13.tgz",
+      "integrity": "sha512-4Wqb8ii7q6igRhjVzPBijPXaOfp24LgOL6lfS7wwvZkN6a+IUd1/30/FPnqvCUUFwR9RzjgW7uBv9bx06oL5IA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/rfc": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@cfdi/rfc/-/rfc-0.0.10.tgz",
+      "integrity": "sha512-zGgjewfrLfmda5qL8J1rRUbJvP/dqhn5ymxVY4anaY+4UJyUYD/eDYoUjd43NPcqPROlGY8K5q6hv80qc7Ts5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/transform": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/transform/-/transform-4.0.13.tgz",
+      "integrity": "sha512-VcyO9W9mJ80w51xcg/Eyg/M3Wnkand2db34t/KFN/XyhXaLBuGosNS2Nd1xriWAWEpX+wUwU4PI/Wf84kP1L5A==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/types": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@cfdi/types/-/types-4.0.13.tgz",
+      "integrity": "sha512-bXIXlkmZfWyGfR+EQpVejcwztE4yBfmeDURuW4c+89qjoNkBTogZ8Prggoup9IQOdAzdFOtRY1Thj9JIqigfNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.15",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/xsd": "4.0.15",
+        "@saxon-he/cli": "12.5.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/types/node_modules/@cfdi/complementos": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/complementos/-/complementos-4.0.15.tgz",
+      "integrity": "sha512-1wOgCoRfLwPuSEql/xhiUX8g9XqKh2LowXWRdop8Bxlxm2bW+zaOmMMr92htMOpl0q9d/vlCVIweilV9NYozdg==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/types/node_modules/@cfdi/xsd": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cfdi/xsd/-/xsd-4.0.15.tgz",
+      "integrity": "sha512-AzRdA8tiDptTPfX9CzpVEcD6mwaVSd06Jhex7xoB1nuG+E9IayHrAtFEy1dmwtjOVRIYBA3VfXj5VqBtm2c2rw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "xml-js": "^1.6.11",
+        "xslt": "^0.9.1",
+        "xslt-processor": "^0.11.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/utils": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cfdi/utils/-/utils-4.0.16.tgz",
+      "integrity": "sha512-QYbDGK7AJcEKyZeJDiqjpt+egFuuW/5ckRp3WSznF9I3VojwbvlL2GI/3nBazRLCHYZxSMZkmm2ErEqkgI05Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/xml": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@cfdi/xml/-/xml-4.0.17.tgz",
+      "integrity": "sha512-/09ILXndVQolwluwK39uPe6jr1SFVwQToxH2BAcmhONP3BYsd0ryV9nDjNn0yclZWaiP8o7712DJFkjlXRvYLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfdi/catalogos": "4.0.15",
+        "@cfdi/complementos": "4.0.16",
+        "@cfdi/csd": "4.0.15",
+        "@cfdi/xsd": "4.0.16",
+        "@saxon-he/cli": "12.5.1",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cfdi/xsd": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cfdi/xsd/-/xsd-4.0.16.tgz",
+      "integrity": "sha512-hi12PuGAGWEm6md5YG8ChleUipj3mYrsUVnD7Seuw/2zXeopwcRiW7F8M4oBE1qImuto+CbHzuCq6qN5ZTy9EA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "xml-js": "^1.6.11",
+        "xslt": "^0.9.1",
+        "xslt-processor": "^0.11.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@clir/openssl": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@clir/openssl/-/openssl-0.0.16.tgz",
+      "integrity": "sha512-LgXVIW0aLctlwJWxw6NAhNnzPNZfR0PUqXnsRb3KV/dALqI4M0GpPhwovnYN4eoy0VtWAK0BjM40greyjGVWxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/execa": "^6.1.1-cjs.1",
+        "moment": "^2.29.4",
+        "node-forge": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@esm2cjs/execa": {
+      "version": "6.1.1-cjs.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/execa/-/execa-6.1.1-cjs.1.tgz",
+      "integrity": "sha512-FHxfnmuDIjY1VS/BLzDkL8EkbcFvi8s6x1nYQ1Nyu0An0n88EJcGhDBcRWLFwt3C3nT7xwI+MwHRH1TZcAFW2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/human-signals": "^3.0.1",
+        "@esm2cjs/is-stream": "^3.0.0",
+        "@esm2cjs/npm-run-path": "^5.1.1-cjs.0",
+        "@esm2cjs/onetime": "^6.0.1-cjs.0",
+        "@esm2cjs/strip-final-newline": "^3.0.1-cjs.0",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "merge-stream": "^2.0.0",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-QZme4eF/PwTpeSbMB4AaWGQ4VSygzE30jI+Oas1NPTtZQAgcHwWVDOQpIW8FUmtzn5Q+2cS7AjnTzbtqtc5P6g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-qcBscHlJpZFOD5nnmMHkzOrq2xyvsp9fbVreQLS8x2LOs8N3CrNi3fqvFY0GVJR+YSOHscwhG9T5t4Ck7R7QGw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-LIIAjcpjLr4rcbYmRQ+eRu55Upy/MMB78seIlwqbnyiA+cTa1/pxWnJ1NHJQrw6tx2wMQmlYoJj+wf16NjWH6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/npm-run-path": {
+      "version": "5.1.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/npm-run-path/-/npm-run-path-5.1.1-cjs.0.tgz",
+      "integrity": "sha512-CWeAIyE8iNSCgP2ItPE8iPgS+lACqgH+MuFRaWOIl2T7hnHqPFfhAJJ/LcLJJ/RMIxNMeenjFMwc91HW7NWr1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/onetime": {
+      "version": "6.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/onetime/-/onetime-6.0.1-cjs.0.tgz",
+      "integrity": "sha512-MkZMZSxrSC/6yUuAw6Azc56XOgwHQQIsNDlO/zgFmOcycJBhRwRuc/gdYUUOFNZIh7y+f0JSIxkNdJPFvJ5W0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-fKzZ3uIIP4j+7WfyG0MEkomGHL0hUXWCx1kY2Zct3GTdl4pyY+3k5lCUxjgdDa2Ld1BCjMNorXnRHiBP6jW6CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/strip-final-newline": {
+      "version": "3.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/strip-final-newline/-/strip-final-newline-3.0.1-cjs.0.tgz",
+      "integrity": "sha512-o41riCGPiOEStayoikBCAqwa6igbv9L9rP+k5UCfQ24EJD/wGrdDs/KTNwkHG5JzDK3T60D5dMkWkLKEPy8gjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@saxon-he/cli": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@saxon-he/cli/-/cli-12.5.1.tgz",
+      "integrity": "sha512-j4wZxRVlpe0v//nGMPctiW/ZQmgp1I51pOWsjZmgwzrA8Fc7gQhARI6rZojmb+ne3iWudseq896dVc1HsHqTCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@esm2cjs/execa": "^6.1.1-cjs.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/curp": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/curp/-/curp-1.3.1.tgz",
+      "integrity": "sha512-DoUGrXK7qe6qnSgumTGa9yULrMJy/1Npsgt0LkGkjWXfL/xVyJPcAQgyEJpNaJQjOlCvdEZWJ2K9vNlTmYrHHw==",
+      "license": "GPL-3.0",
+      "engines": {
+        "npm": ">= 8.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/validate-rfc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/validate-rfc/-/validate-rfc-2.0.3.tgz",
+      "integrity": "sha512-WS7CyAz/sfzx6DryOPZvprqz7uxHcQh1yhzDunNX1vidSmprfN7Og66VRpCyU21U82Vzkof5/bOIOKan3dEXLA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xslt": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/xslt/-/xslt-0.9.1.tgz",
+      "integrity": "sha512-2eFkaiFRVkVzedBKYv3MUYmvvK9103NTNFGsyFhLim0Pad0q5yXp2j9tQM2lFW1gFr9fSXV70RRrdcRM7YdRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.33"
+      }
+    },
+    "node_modules/xslt-processor": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/xslt-processor/-/xslt-processor-0.11.7.tgz",
+      "integrity": "sha512-66vcLzwSP4dAvzm4O+Lq20Su03ckrGaYn1kbdCNDp9HaaBZgHJJNZlrVSkvfEuKNvqd4wk9XGU5Rvi+eUJqf+w==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "he": "^1.2.0"
+      }
+    }
+  }
+}

--- a/packages/test-esm/package.json
+++ b/packages/test-esm/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "test-esm",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs",
+    "update-versions": "node update-versions.mjs"
+  },
+  "dependencies": {
+    "@cfdi/xml": "4.0.17",
+    "@cfdi/complementos": "4.0.16",
+    "@cfdi/xsd": "4.0.16",
+    "@cfdi/csd": "4.0.15",
+    "@cfdi/csf": "4.0.15",
+    "@cfdi/catalogos": "4.0.15",
+    "@cfdi/utils": "4.0.16",
+    "@cfdi/rfc": "0.0.10",
+    "@cfdi/types": "4.0.13",
+    "@cfdi/transform": "4.0.13",
+    "@cfdi/2json": "4.0.13",
+    "@cfdi/expresiones": "4.0.13",
+    "@cfdi/elements": "4.0.13",
+    "@clir/openssl": "0.0.16",
+    "@saxon-he/cli": "12.5.1"
+  }
+}

--- a/packages/test-esm/routes/cfdi-2json.mjs
+++ b/packages/test-esm/routes/cfdi-2json.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/2json',
+  name: '@cfdi/2json',
+  async test() {
+    const pkg = await import('@cfdi/2json');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-catalogos.mjs
+++ b/packages/test-esm/routes/cfdi-catalogos.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/catalogos',
+  name: '@cfdi/catalogos',
+  async test() {
+    const pkg = await import('@cfdi/catalogos');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-complementos.mjs
+++ b/packages/test-esm/routes/cfdi-complementos.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/complementos',
+  name: '@cfdi/complementos',
+  async test() {
+    const pkg = await import('@cfdi/complementos');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-csd.mjs
+++ b/packages/test-esm/routes/cfdi-csd.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/csd',
+  name: '@cfdi/csd',
+  async test() {
+    const pkg = await import('@cfdi/csd');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-csf.mjs
+++ b/packages/test-esm/routes/cfdi-csf.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/csf',
+  name: '@cfdi/csf',
+  async test() {
+    const pkg = await import('@cfdi/csf');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-elements.mjs
+++ b/packages/test-esm/routes/cfdi-elements.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/elements',
+  name: '@cfdi/elements',
+  async test() {
+    const pkg = await import('@cfdi/elements');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-expresiones.mjs
+++ b/packages/test-esm/routes/cfdi-expresiones.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/expresiones',
+  name: '@cfdi/expresiones',
+  async test() {
+    const pkg = await import('@cfdi/expresiones');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-rfc.mjs
+++ b/packages/test-esm/routes/cfdi-rfc.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/rfc',
+  name: '@cfdi/rfc',
+  async test() {
+    const pkg = await import('@cfdi/rfc');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-transform.mjs
+++ b/packages/test-esm/routes/cfdi-transform.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/transform',
+  name: '@cfdi/transform',
+  async test() {
+    const pkg = await import('@cfdi/transform');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-types.mjs
+++ b/packages/test-esm/routes/cfdi-types.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/types',
+  name: '@cfdi/types',
+  async test() {
+    const pkg = await import('@cfdi/types');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-utils.mjs
+++ b/packages/test-esm/routes/cfdi-utils.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/utils',
+  name: '@cfdi/utils',
+  async test() {
+    const pkg = await import('@cfdi/utils');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-xml.mjs
+++ b/packages/test-esm/routes/cfdi-xml.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/xml',
+  name: '@cfdi/xml',
+  async test() {
+    const pkg = await import('@cfdi/xml');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/cfdi-xsd.mjs
+++ b/packages/test-esm/routes/cfdi-xsd.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@cfdi/xsd',
+  name: '@cfdi/xsd',
+  async test() {
+    const pkg = await import('@cfdi/xsd');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/clir-openssl.mjs
+++ b/packages/test-esm/routes/clir-openssl.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@clir/openssl',
+  name: '@clir/openssl',
+  async test() {
+    const pkg = await import('@clir/openssl');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/routes/saxon-he-cli.mjs
+++ b/packages/test-esm/routes/saxon-he-cli.mjs
@@ -1,0 +1,9 @@
+export default {
+  path: '/@saxon-he/cli',
+  name: '@saxon-he/cli',
+  async test() {
+    const pkg = await import('@saxon-he/cli');
+    const exports = Object.keys(pkg);
+    return { exports };
+  },
+};

--- a/packages/test-esm/server.mjs
+++ b/packages/test-esm/server.mjs
@@ -1,0 +1,91 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = process.env.PORT || 3002;
+const routesDir = path.join(__dirname, 'routes');
+
+async function loadRoutes() {
+  const routes = {};
+  const files = fs.readdirSync(routesDir).filter(f => f.endsWith('.mjs'));
+
+  for (const file of files) {
+    const mod = await import(path.join(routesDir, file));
+    const route = mod.default;
+    routes[route.path] = route;
+  }
+
+  return routes;
+}
+
+function json(res, data, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data, null, 2));
+}
+
+const routes = await loadRoutes();
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const pathname = url.pathname;
+
+  if (pathname === '/') {
+    const available = Object.values(routes).map(r => ({
+      name: r.name,
+      path: r.path,
+    }));
+    return json(res, {
+      type: 'esm',
+      routes: available,
+      endpoints: {
+        '/': 'Lista de rutas',
+        '/all': 'Ejecutar todas las rutas',
+        '/@scope/pkg': 'Ruta individual',
+      },
+    });
+  }
+
+  if (pathname === '/all') {
+    const results = [];
+    let ok = 0;
+    let failed = 0;
+
+    for (const route of Object.values(routes)) {
+      try {
+        const result = await route.test();
+        results.push({ name: route.name, status: 'ok', ...result });
+        ok++;
+      } catch (err) {
+        results.push({ name: route.name, status: 'error', message: err.message });
+        failed++;
+      }
+    }
+
+    return json(res, {
+      type: 'esm',
+      timestamp: new Date().toISOString(),
+      summary: { total: results.length, ok, failed },
+      results,
+    });
+  }
+
+  const route = routes[pathname];
+  if (route) {
+    try {
+      const result = await route.test();
+      return json(res, { name: route.name, status: 'ok', ...result });
+    } catch (err) {
+      return json(res, { name: route.name, status: 'error', message: err.message }, 500);
+    }
+  }
+
+  json(res, { error: 'Not found', available: Object.keys(routes) }, 404);
+});
+
+server.listen(PORT, () => {
+  console.log(`[ESM] Server running on http://localhost:${PORT}`);
+  console.log(`Routes loaded: ${Object.keys(routes).length}`);
+  Object.keys(routes).forEach(r => console.log(`  ${r}`));
+});

--- a/packages/test-esm/update-versions.mjs
+++ b/packages/test-esm/update-versions.mjs
@@ -1,0 +1,45 @@
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rushJsonPath = resolve(__dirname, '../../rush.json');
+const pkgJsonPath = resolve(__dirname, 'package.json');
+
+const rush = JSON.parse(readFileSync(rushJsonPath, 'utf-8'));
+const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+
+const publishable = rush.projects
+  .filter(p => p.shouldPublish)
+  .map(p => p.packageName);
+
+console.log(`Found ${publishable.length} publishable packages in rush.json\n`);
+
+const updated = {};
+const errors = [];
+
+for (const name of publishable) {
+  try {
+    const raw = execSync(`npm view ${name} versions --json 2>/dev/null`, {
+      encoding: 'utf-8',
+    });
+    const versions = JSON.parse(raw);
+    const arr = Array.isArray(versions) ? versions : [versions];
+    const latest = arr[arr.length - 1];
+    updated[name] = latest;
+    console.log(`  ${name}: ${latest}`);
+  } catch {
+    errors.push(name);
+    console.log(`  ${name}: NOT FOUND on npm (skipped)`);
+  }
+}
+
+pkgJson.dependencies = updated;
+writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
+
+console.log(`\nUpdated ${Object.keys(updated).length} dependencies in package.json`);
+if (errors.length) {
+  console.log(`Skipped ${errors.length}: ${errors.join(', ')}`);
+}
+console.log('\nRun "npm install" to install the updated versions.');


### PR DESCRIPTION
## Summary
- Remove `--apply` flag from prerelease `rush publish` — it was reverting file changes after publish, preventing version bumps from being committed
- Add publish summary at end of loop: total scopes, published count, failed count
- Fix commit step: add `git add -A` before checking for staged changes
- Keep `git add -A` after each successful publish to protect changes from `git checkout -- .` on failures

## Fixes
- Version bumps now persist after publish (committed + pushed to branch)
- `github-release.js` can now detect bumped packages via `git diff`
- CHANGELOG.json entries will be generated correctly

## Test plan
- [ ] Verify publish summary appears in Actions log
- [ ] Verify version bumps are committed and pushed to dev
- [ ] Verify GitHub Releases are created