### PR TITLE
feat: update readmes with visual ecosystem cards

### DIFF
--- a/packages/cfdi/catalogos/README.md
+++ b/packages/cfdi/catalogos/README.md
@@ -1,6 +1,128 @@
-# @cfdi/catalogos
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="400" />
+  </a>
+</p>
 
-Catalogos oficiales del SAT para CFDI 4.0. Contiene enums, tipos y listas de valores para formas de pago, metodos de pago, regimenes fiscales, tipos de comprobante, usos de CFDI, impuestos y exportacion.
+<h3 align="center">Catalogos oficiales del SAT para CFDI 4.0 como enums TypeScript</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+    <img src="https://img.shields.io/npm/v/@cfdi/catalogos?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+    <img src="https://img.shields.io/npm/dm/@cfdi/catalogos?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,52 +130,31 @@ Catalogos oficiales del SAT para CFDI 4.0. Contiene enums, tipos y listas de val
 npm install @cfdi/catalogos
 ```
 
-## Uso
+---
 
-```typescript
-import {
-  FormaPago,
-  MetodoPago,
-  RegimenFiscal,
-  TipoComprobante,
-  UsoCFDI,
-  Impuesto,
-  ExportacionEnum,
-  FormaPagoList,
-} from '@cfdi/catalogos';
+## Soporte
 
-// Usar enums directamente
-const pago = FormaPago.TRANSFERENCIA_ELECTRONICA; // '03'
-const metodo = MetodoPago.PUE; // Pago en Una sola Exhibicion
-const regimen = RegimenFiscal.GENERAL_DE_LEY; // Regimen general
-const tipo = TipoComprobante.INGRESO;
-const uso = UsoCFDI.GASTOS_EN_GENERAL;
-const impuesto = Impuesto.IVA;
-const exportacion = ExportacionEnum.NoAplica; // '01'
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+    <img src="https://img.shields.io/badge/npm-@cfdi/catalogos-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Listas para selects/dropdowns
-console.log(FormaPagoList);
-// [{ label: 'Efectivo', value: '01' }, { label: 'Cheque nominativo', value: '02' }, ...]
-```
-
-## API
-
-| Export | Tipo | Descripcion |
-|--------|------|-------------|
-| `FormaPago` | enum | Claves de forma de pago (01-99) |
-| `FormaPagoList` | array | Lista con label/value para UI |
-| `FormaPagoType` | type | Tipo union de claves validas |
-| `MetodoPago` | enum | PUE, PPD |
-| `RegimenFiscal` | enum | Regimenes fiscales del SAT |
-| `TipoComprobante` | enum | Ingreso, Egreso, Traslado, Nomina, Pago |
-| `UsoCFDI` | enum | Usos del CFDI |
-| `Impuesto` | enum | IVA, ISR, IEPS |
-| `ExportacionEnum` | enum | NoAplica, Definitiva, Temporal |
-| `ExportacionType` | type | Tipo union de claves de exportacion |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/complementos/README.md
+++ b/packages/cfdi/complementos/README.md
@@ -1,6 +1,128 @@
-# @cfdi/complementos
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/complementos">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="400" />
+  </a>
+</p>
 
-Complementos fiscales para CFDI 3.3 y 4.0. Proporciona las clases necesarias para agregar complementos al comprobante fiscal conforme a las especificaciones del SAT.
+<h3 align="center">Complementos fiscales del SAT para CFDI 4.0: pagos, nomina, comercio exterior, carta porte</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/complementos">
+    <img src="https://img.shields.io/npm/v/@cfdi/complementos?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/complementos">
+    <img src="https://img.shields.io/npm/dm/@cfdi/complementos?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,115 +130,31 @@ Complementos fiscales para CFDI 3.3 y 4.0. Proporciona las clases necesarias par
 npm install @cfdi/complementos
 ```
 
-## Uso
+---
 
-### Complemento de Pagos 2.0
+## Soporte
 
-```typescript
-import { Pagos20, Pago20, Pago20Relacionado, Pago20Impuestos } from '@cfdi/complementos';
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/complementos">
+    <img src="https://img.shields.io/badge/npm-@cfdi/complementos-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-const pagos = new Pagos20();
-const pago = new Pago20({
-  FechaPago: '2024-01-15T12:00:00',
-  FormaDePagoP: '01',
-  MonedaP: 'MXN',
-  Monto: '1000.00',
-});
-
-const relacionado = new Pago20Relacionado({
-  IdDocumento: 'UUID-DEL-CFDI',
-  MonedaDR: 'MXN',
-  NumParcialidad: '1',
-  ImpSaldoAnt: '1000.00',
-  ImpPagado: '1000.00',
-  ImpSaldoInsoluto: '0.00',
-});
-
-const complemento = pagos.getComplement();
-```
-
-### Complemento Carta Porte 2.0
-
-```typescript
-import { CartaPorte20 } from '@cfdi/complementos';
-
-const cartaPorte = new CartaPorte20({
-  TranspInternac: 'No',
-  TotalDistRec: '100.00',
-});
-
-const complemento = cartaPorte.getComplement();
-```
-
-### Timbre Fiscal Digital (TFD)
-
-```typescript
-import { Tfd } from '@cfdi/complementos';
-
-const tfd = new Tfd({
-  Version: '1.1',
-  UUID: 'DC2ED983-D108-402E-A2FD-C08EDDA23C47',
-  FechaTimbrado: '2024-01-15T18:05:05',
-  SelloCFD: '...',
-  SelloSAT: '...',
-  NoCertificadoSAT: '30001000000400002495',
-});
-```
-
-### Clase base Complemento
-
-Todos los complementos extienden de la clase abstracta `Complemento<T>`, que provee el metodo `getComplement()` para obtener la estructura XML del complemento.
-
-```typescript
-import { Complemento } from '@cfdi/complementos';
-
-// getComplement() retorna:
-// {
-//   complement: T,           // Datos del complemento
-//   key: string,             // Clave del nodo XML
-//   schemaLocation: string[],// URLs del esquema XSD
-//   xmlns: string,           // Namespace XML
-//   xmlnskey: string,        // Prefijo del namespace
-// }
-```
-
-## API
-
-### Complementos CFDI 4.0
-
-| Clase | Descripcion |
-|-------|-------------|
-| `Pagos20` / `Pago20` | Recepcion de pagos 2.0 |
-| `CartaPorte20` | Carta porte 2.0 |
-| `Aerolineas` | Aerolineas |
-| `Ine` | Instituto Nacional Electoral |
-| `Iedu` | Instituciones educativas |
-
-### Complementos CFDI 3.3
-
-| Clase | Descripcion |
-|-------|-------------|
-| `Tfd` | Timbre fiscal digital |
-| `Cce11` | Comercio exterior 1.1 |
-| `Nomina12` | Nomina 1.2 |
-| `Divisas` | Divisas |
-| `Donat` | Donatarias |
-| `LeyendaFisc` | Leyendas fiscales |
-| `VehiculoUsado` | Vehiculo usado |
-| `Destruccion` | Certificado de destruccion |
-| `ObrasArte` | Obras de arte |
-| `ServicioParcial` | Servicios parciales de construccion |
-| `Implocal` | Impuestos locales |
-| `Hidrocarburos` | Gastos e ingresos de hidrocarburos |
-| `Detallista` | Detallista |
-| `Spei` | SPEI |
-| `ValesDeDespensa` | Vales de despensa |
-| `ConsumoDeCombustibles11` | Consumo de combustibles 1.1 |
-| `VentaVehiculos` | Venta de vehiculos |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/csd/README.md
+++ b/packages/cfdi/csd/README.md
@@ -1,6 +1,128 @@
-# @cfdi/csd
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/csd">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="400" />
+  </a>
+</p>
 
-Manejo de Certificados de Sello Digital (CSD) del SAT. Permite leer archivos `.cer` y `.key`, extraer informacion del certificado y firmar cadenas originales.
+<h3 align="center">Certificados de Sello Digital (CSD) - lectura de archivos .cer y .key para CFDI</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/csd">
+    <img src="https://img.shields.io/npm/v/@cfdi/csd?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/csd">
+    <img src="https://img.shields.io/npm/dm/@cfdi/csd?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,80 +130,31 @@ Manejo de Certificados de Sello Digital (CSD) del SAT. Permite leer archivos `.c
 npm install @cfdi/csd
 ```
 
-## Uso
+---
 
-### Certificado (.cer)
+## Soporte
 
-```typescript
-import { cer } from '@cfdi/csd';
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/csd">
+    <img src="https://img.shields.io/badge/npm-@cfdi/csd-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Cargar archivo de certificado
-cer.setFile('/ruta/al/certificado.cer');
-
-// Obtener PEM
-const pem = cer.getPem();
-const pemSinHeaders = cer.getPem({ begin: true }); // Sin BEGIN/END
-
-// Informacion del certificado
-const noCertificado = cer.getNoCer();    // Numero de certificado
-const serial = cer.serial();              // Numero de serie hex
-const fechas = cer.date();                // { startDate, endDate }
-const vigencia = cer.validity();          // { notBefore, notAfter }
-const sujeto = cer.subject();             // Datos del titular
-const emisor = cer.issuer();              // Datos del emisor
-const llave = cer.pubkey();               // Llave publica PEM
-const huella = cer.fingerPrint();         // Huella digital
-
-// Verificar si el certificado expira en N segundos
-const expira = cer.checkend(86400); // Verificar si expira en 24 horas
-```
-
-### Llave privada (.key)
-
-```typescript
-import { key } from '@cfdi/csd';
-
-// Cargar archivo de llave con contrasena
-key.setFile('/ruta/a/llave.key', 'contrasena123');
-
-// Obtener PEM
-const pem = key.getPem();
-
-// Firmar cadena original
-const firma = key.signatureHexForge('cadena original');    // Firma con node-forge
-const firma2 = key.signatureHexCripto('cadena original');  // Firma con crypto nativo
-```
-
-## API
-
-### Modulo `cer`
-
-| Funcion | Descripcion |
-|---------|-------------|
-| `setFile(path)` | Carga un archivo .cer o .pem |
-| `getPem(options?)` | Retorna el certificado en formato PEM |
-| `getNoCer()` | Retorna el numero de certificado |
-| `serial()` | Retorna el numero de serie hexadecimal |
-| `date(format?)` | Retorna fechas de inicio y fin de vigencia |
-| `validity()` | Retorna `{ notBefore, notAfter }` como objetos Date |
-| `checkend(seconds)` | Verifica si el certificado expira en N segundos |
-| `subject()` | Retorna los datos del titular del certificado |
-| `issuer()` | Retorna los datos del emisor del certificado |
-| `pubkey(options?)` | Retorna la llave publica en formato PEM |
-| `fingerPrint()` | Retorna la huella digital del certificado |
-
-### Modulo `key`
-
-| Funcion | Descripcion |
-|---------|-------------|
-| `setFile(path, password?)` | Carga un archivo .key con contrasena |
-| `getPem(options?)` | Retorna la llave privada en formato PEM |
-| `signatureHexForge(message)` | Firma SHA256 usando node-forge, retorna base64 |
-| `signatureHexCripto(message)` | Firma SHA256 usando crypto nativo, retorna base64 |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/csf/README.md
+++ b/packages/cfdi/csf/README.md
@@ -1,6 +1,128 @@
-# @cfdi/csf
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/csf">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="400" />
+  </a>
+</p>
 
-Extraccion de datos de la Constancia de Situacion Fiscal (CSF) del SAT a partir de un archivo PDF. Parsea el documento y retorna los datos estructurados del contribuyente.
+<h3 align="center">Lectura y parseo de Constancia de Situacion Fiscal (CSF) del SAT</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/csf">
+    <img src="https://img.shields.io/npm/v/@cfdi/csf?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/csf">
+    <img src="https://img.shields.io/npm/dm/@cfdi/csf?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,53 +130,31 @@ Extraccion de datos de la Constancia de Situacion Fiscal (CSF) del SAT a partir 
 npm install @cfdi/csf
 ```
 
-## Uso
+---
 
-```typescript
-import { csf } from '@cfdi/csf';
+## Soporte
 
-// Extraer datos estructurados
-const datos = await csf('/ruta/a/constancia.pdf');
-console.log(datos);
-// {
-//   id_cif: '...',
-//   rfc: 'XAXX010101000',
-//   curp: 'XAXX010101HDFRRR09',
-//   nombre: 'NOMBRE',
-//   primer_apellido: 'APELLIDO',
-//   segundo_apellido: 'APELLIDO',
-//   fecha_inicio_de_operaciones: '01/01/2020',
-//   cp: '06600',
-//   tipo_de_vialidad: 'CALLE',
-//   nombre_de_vialidad: '...',
-//   numero_exterior: '10',
-//   numero_interior: '',
-//   nombre_de_la_colonia: '...',
-//   nombre_de_la_localidad: '...',
-//   nombre_del_municipio: '...',
-//   nombre_de_la_entidad_federativa: '...',
-//   regimen: '...',
-//   ...
-// }
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/csf">
+    <img src="https://img.shields.io/badge/npm-@cfdi/csf-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Obtener datos crudos del PDF (array de strings)
-const datosCrudos = await csf('/ruta/a/constancia.pdf', true);
-```
-
-## API
-
-### `csf(constancia, onlyData?)`
-
-| Parametro | Tipo | Descripcion |
-|-----------|------|-------------|
-| `constancia` | `string` | Ruta al archivo PDF de la constancia |
-| `onlyData` | `boolean` | Si es `true`, retorna el array crudo de textos extraidos. Por defecto `false` |
-
-**Retorna:** Un objeto con los campos del contribuyente (RFC, CURP, nombre, domicilio, regimen, etc.) o un array de strings si `onlyData` es `true`.
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/elements/README.md
+++ b/packages/cfdi/elements/README.md
@@ -1,6 +1,128 @@
-# @cfdi/elements
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/elements">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="400" />
+  </a>
+</p>
 
-Elementos estructurales del comprobante CFDI. Define las constantes y clases base que representan los nodos XML de un CFDI 4.0.
+<h3 align="center">Elementos estructurales del comprobante CFDI 4.0: emisor, receptor, conceptos</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/elements">
+    <img src="https://img.shields.io/npm/v/@cfdi/elements?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/elements">
+    <img src="https://img.shields.io/npm/dm/@cfdi/elements?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,78 +130,31 @@ Elementos estructurales del comprobante CFDI. Define las constantes y clases bas
 npm install @cfdi/elements
 ```
 
-## Uso
+---
 
-```typescript
-import { Elemento } from '@cfdi/elements';
-import {
-  COMPROBANTE,
-  EMISOR,
-  RECEPTOR,
-  CONCEPTOS,
-  CONCEPTO,
-  IMPUESTOS,
-  TRASLADOS,
-  TRASLADO,
-  COMPLEMENTO,
-} from '@cfdi/elements';
+## Soporte
 
-// Usar constantes de tags XML
-console.log(COMPROBANTE); // 'cfdi:Comprobante'
-console.log(EMISOR);      // 'cfdi:Emisor'
-console.log(RECEPTOR);    // 'cfdi:Receptor'
-console.log(CONCEPTOS);   // 'cfdi:Conceptos'
-console.log(CONCEPTO);    // 'cfdi:Concepto'
-console.log(IMPUESTOS);   // 'cfdi:Impuestos'
-```
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/elements">
+    <img src="https://img.shields.io/badge/npm-@cfdi/elements-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-### Clase Elemento
-
-Clase generica base para representar nodos XML con prefijo de namespace.
-
-```typescript
-const concepto = new Elemento('cfdi:Concepto');
-
-concepto.tag();    // 'cfdi:Concepto'
-concepto.prefix(); // 'cfdi'
-concepto.name();   // 'Concepto'
-```
-
-### Complementos
-
-El paquete tambien exporta elementos de complementos como Carta Porte 3.1 y Vehiculo Usado.
-
-```typescript
-import { CartaPorte31, VehiculoUsado } from '@cfdi/elements';
-```
-
-## API
-
-### Constantes
-
-| Constante | Valor |
-|-----------|-------|
-| `COMPROBANTE` | `'cfdi:Comprobante'` |
-| `EMISOR` | `'cfdi:Emisor'` |
-| `RECEPTOR` | `'cfdi:Receptor'` |
-| `CONCEPTOS` | `'cfdi:Conceptos'` |
-| `CONCEPTO` | `'cfdi:Concepto'` |
-| `IMPUESTOS` | `'cfdi:Impuestos'` |
-| `TRASLADOS` | `'cfdi:Traslados'` |
-| `TRASLADO` | `'cfdi:Traslado'` |
-| `COMPLEMENTO` | `'cfdi:Complemento'` |
-
-### Clase `Elemento<T>`
-
-| Metodo | Retorno | Descripcion |
-|--------|---------|-------------|
-| `tag()` | `string` | Nombre completo del tag (ej. `cfdi:Concepto`) |
-| `prefix()` | `string` | Prefijo del namespace (ej. `cfdi`) |
-| `name()` | `string` | Nombre del elemento sin prefijo (ej. `Concepto`) |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/expresiones/README.md
+++ b/packages/cfdi/expresiones/README.md
@@ -1,6 +1,128 @@
-# @cfdi/expresiones
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="400" />
+  </a>
+</p>
 
-Generacion de expresiones impresas del CFDI para verificacion y codigos QR. Procesa un archivo XML de CFDI y extrae los valores necesarios para construir la cadena de verificacion.
+<h3 align="center">Generacion de expresiones impresas (codigo QR) para CFDI</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+    <img src="https://img.shields.io/npm/v/@cfdi/expresiones?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+    <img src="https://img.shields.io/npm/dm/@cfdi/expresiones?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,55 +130,31 @@ Generacion de expresiones impresas del CFDI para verificacion y codigos QR. Proc
 npm install @cfdi/expresiones
 ```
 
-## Uso
+---
 
-```typescript
-import { Transform } from '@cfdi/expresiones';
+## Soporte
 
-// Cargar archivo XML del CFDI
-const transform = new Transform();
-transform.s('/ruta/al/cfdi.xml');
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+    <img src="https://img.shields.io/badge/npm-@cfdi/expresiones-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Generar la expresion impresa
-const expresion = await transform.run();
-// Resultado: ||valor1|valor2|valor3|...||
-```
-
-### Ejemplo completo
-
-```typescript
-import { Transform } from '@cfdi/expresiones';
-
-const transform = new Transform();
-
-// Cargar el XML (usa @cfdi/2json internamente para parsear)
-transform.s('/ruta/factura.xml');
-
-// Configurar advertencias (opcional)
-transform.warnings('silent');
-
-// Obtener la expresion impresa
-const cadena = await transform.run();
-console.log(cadena);
-// ||4.0|2024-01-15T12:00:00|01|1000.00|...||
-```
-
-## API
-
-### Clase `Transform`
-
-| Metodo | Retorno | Descripcion |
-|--------|---------|-------------|
-| `s(archivo)` | `Transform` | Carga y parsea un archivo XML de CFDI |
-| `run()` | `Promise<string>` | Genera la expresion impresa con formato `\|\|valor1\|valor2\|...\|\|` |
-| `json(xslPath)` | `Transform` | Establece la ruta del archivo XSLT |
-| `warnings(type)` | `Transform` | Configura el nivel de advertencias |
-
-La expresion generada contiene los valores del comprobante en orden: atributos, emisor, receptor, conceptos, impuestos y complemento. Se omiten automaticamente los namespaces, esquemas, certificado y sello.
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/rfc/README.md
+++ b/packages/cfdi/rfc/README.md
@@ -1,6 +1,128 @@
-# @cfdi/rfc
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/rfc">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="400" />
+  </a>
+</p>
 
-Validacion de RFC (Registro Federal de Contribuyentes) mexicano. Verifica formato, fecha, digito verificador y palabras inconvenientes.
+<h3 align="center">Validacion de RFC mexicano - persona fisica y moral con digito verificador</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/rfc">
+    <img src="https://img.shields.io/npm/v/@cfdi/rfc?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/rfc">
+    <img src="https://img.shields.io/npm/dm/@cfdi/rfc?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,41 +130,31 @@ Validacion de RFC (Registro Federal de Contribuyentes) mexicano. Verifica format
 npm install @cfdi/rfc
 ```
 
-## Uso
+---
 
-```typescript
-import { rfc } from '@cfdi/rfc';
+## Soporte
 
-// Validar un RFC
-const resultado = rfc.validate('GARC850101AB1');
-// { isValid: true, type: 'PF', rfc: 'GARC850101AB1' }
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/rfc">
+    <img src="https://img.shields.io/badge/npm-@cfdi/rfc-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-const resultado2 = rfc.validate('ABC010101XY9');
-// { isValid: false, type: '', rfc: 'ABC010101XY9' }
-
-// Obtener tipo de RFC
-const tipo = rfc.getType('GARC850101AB1'); // 'PF' (Persona Fisica)
-const tipo2 = rfc.getType('ABC010101XY9'); // 'PM' (Persona Moral)
-
-// Verificar palabras inconvenientes del SAT
-const prohibido = rfc.hasForbiddenWords('BUEI850101AB1'); // true
-```
-
-## API
-
-### Modulo `rfc`
-
-| Funcion | Retorna | Descripcion |
-|---------|---------|-------------|
-| `validate(input)` | `{ isValid, type, rfc }` | Valida formato, fecha, digito verificador y palabras inconvenientes |
-| `getType(rfc)` | `string` | Retorna `'PF'` (persona fisica, 13 caracteres) o `'PM'` (persona moral, 12 caracteres) |
-| `hasForbiddenWords(rfc)` | `boolean` | Verifica si los primeros 4 caracteres estan en la lista de palabras inconvenientes del SAT |
-
-Sin dependencias externas.
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/transform/README.md
+++ b/packages/cfdi/transform/README.md
@@ -1,6 +1,128 @@
-# @cfdi/transform
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/transform">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="400" />
+  </a>
+</p>
 
-Transformacion de datos XML CFDI. Extrae los valores de un comprobante fiscal XML y genera una cadena con formato de expresion impresa.
+<h3 align="center">Transformacion XSLT para generacion de cadena original de CFDI</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/transform">
+    <img src="https://img.shields.io/npm/v/@cfdi/transform?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/transform">
+    <img src="https://img.shields.io/npm/dm/@cfdi/transform?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,50 +130,31 @@ Transformacion de datos XML CFDI. Extrae los valores de un comprobante fiscal XM
 npm install @cfdi/transform
 ```
 
-## Uso
+---
 
-```typescript
-import { Transform } from '@cfdi/transform';
+## Soporte
 
-// Crear instancia con el XML parseado
-const transform = new Transform(xmlObject);
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/transform">
+    <img src="https://img.shields.io/badge/npm-@cfdi/transform-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Ejecutar la transformacion para obtener la cadena de valores
-const resultado = await transform.run();
-// Resultado: ||valor1|valor2|valor3|...||
-```
-
-### Configuracion adicional
-
-```typescript
-const transform = new Transform(xmlObject);
-
-// Especificar ruta XSLT
-transform.json('/ruta/al/archivo.xsl');
-
-// Configurar advertencias
-transform.warnings('silent');
-
-// Ejecutar
-const cadena = await transform.run();
-```
-
-## API
-
-### Clase `Transform`
-
-| Metodo | Retorno | Descripcion |
-|--------|---------|-------------|
-| `constructor(xml)` | `Transform` | Recibe el objeto XML parseado del CFDI |
-| `run()` | `Promise<string>` | Extrae los valores del comprobante y retorna la cadena con formato `\|\|valor1\|valor2\|...\|\|` |
-| `json(xslPath)` | `Transform` | Establece la ruta del archivo XSLT |
-| `warnings(type)` | `Transform` | Configura el nivel de advertencias (`'silent'` por defecto) |
-
-La transformacion recorre la estructura del comprobante en el siguiente orden: atributos, InformacionGlobal, CfdiRelacionados, Emisor, Receptor, Conceptos, Impuestos y Complemento. Omite automaticamente namespaces, esquemas y el sello digital.
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/types/README.md
+++ b/packages/cfdi/types/README.md
@@ -1,6 +1,128 @@
-# @cfdi/types
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/types">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="400" />
+  </a>
+</p>
 
-Definiciones de tipos TypeScript para CFDI 4.0. Proporciona interfaces y tipos para la estructura del comprobante fiscal, sus elementos y complementos.
+<h3 align="center">Interfaces y tipos TypeScript para CFDI 4.0 del SAT</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/types">
+    <img src="https://img.shields.io/npm/v/@cfdi/types?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/types">
+    <img src="https://img.shields.io/npm/dm/@cfdi/types?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,111 +130,31 @@ Definiciones de tipos TypeScript para CFDI 4.0. Proporciona interfaces y tipos p
 npm install @cfdi/types
 ```
 
-## Uso
+---
 
-```typescript
-import {
-  XmlComprobante,
-  XmlConcepto,
-  XmlEmisor,
-  XmlReceptor,
-  XmlImpuestos,
-  XmlRelacionados,
-  CFDIComprobante,
-  XmlComplements,
-} from '@cfdi/types';
+## Soporte
 
-// Definir atributos del comprobante
-const comprobante: CFDIComprobante = {
-  Fecha: '2024-01-15T12:00:00',
-  SubTotal: '1000.00',
-  Total: '1160.00',
-  Moneda: 'MXN',
-  TipoDeComprobante: 'I',
-  Exportacion: '01',
-  MetodoPago: 'PUE',
-  FormaPago: '01',
-  LugarExpedicion: '12345',
-};
-```
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/types">
+    <img src="https://img.shields.io/badge/npm-@cfdi/types-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-### Tipos de complementos
-
-```typescript
-import {
-  Ine,
-  Aerolineas,
-  CartaPorte20,
-  Pago20,
-  Iedu,
-} from '@cfdi/types';
-```
-
-### Tipos de configuracion
-
-```typescript
-import type {
-  Config,
-  SaxonHe,
-  XsltSheet,
-  InvoiceType,
-  InvoiceRelation,
-  TaxSystem,
-} from '@cfdi/types';
-
-// Enums disponibles
-InvoiceType.INGRESO;    // 'I'
-InvoiceType.EGRESO;     // 'E'
-InvoiceType.TRASLADO;   // 'T'
-InvoiceType.NOMINA;     // 'N'
-InvoiceType.PAGO;       // 'P'
-```
-
-## API
-
-### Interfaces del comprobante
-
-| Tipo | Descripcion |
-|------|-------------|
-| `XmlComprobante` | Estructura completa del nodo Comprobante |
-| `CFDIComprobante` | Atributos del comprobante (Fecha, Total, Moneda, etc.) |
-| `XmlEmisor` | Estructura del nodo Emisor |
-| `XmlReceptor` | Estructura del nodo Receptor |
-| `XmlConcepto` | Estructura del nodo Conceptos |
-| `XmlImpuestos` | Estructura del nodo Impuestos |
-| `XmlRelacionados` | Estructura del nodo CfdiRelacionados |
-| `XmlComplements` | Estructura del nodo Complemento |
-
-### Interfaces de complementos
-
-| Tipo | Descripcion |
-|------|-------------|
-| `Ine` | Complemento INE |
-| `Aerolineas` | Complemento de aerolineas |
-| `CartaPorte20` | Complemento carta porte 2.0 |
-| `Pago20` | Complemento de pagos 2.0 |
-| `Iedu` | Complemento instituciones educativas |
-
-### Enums
-
-| Enum | Descripcion |
-|------|-------------|
-| `InvoiceType` | Tipos de comprobante (I, E, T, N, P) |
-| `InvoiceRelation` | Tipos de relacion entre CFDI |
-| `TaxSystem` | Regimenes fiscales |
-
-### Interfaces de configuracion
-
-| Tipo | Descripcion |
-|------|-------------|
-| `Config` | Configuracion general del CFDI |
-| `SaxonHe` | Configuracion del binario Saxon-HE |
-| `XsltSheet` | Ruta a la hoja de transformacion XSLT |
-| `Schema` | Ruta al esquema XSD |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/utils/README.md
+++ b/packages/cfdi/utils/README.md
@@ -1,6 +1,128 @@
-# @cfdi/utils
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/utils">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="400" />
+  </a>
+</p>
 
-Utilidades generales para el ecosistema CFDI. Incluye conversion de numeros a letras en español (para totales en facturas), manejo de logos y utilidades de archivos.
+<h3 align="center">Utilidades para CFDI: conversion de numeros a letras, formateo de montos</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/utils">
+    <img src="https://img.shields.io/npm/v/@cfdi/utils?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/utils">
+    <img src="https://img.shields.io/npm/dm/@cfdi/utils?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,57 +130,31 @@ Utilidades generales para el ecosistema CFDI. Incluye conversion de numeros a le
 npm install @cfdi/utils
 ```
 
-## Uso
+---
 
-### Numeros a letras
+## Soporte
 
-```typescript
-import { NumeroALetras } from '@cfdi/utils';
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/utils">
+    <img src="https://img.shields.io/badge/npm-@cfdi/utils-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-const converter = new NumeroALetras();
-
-// Convertir numero a letras con moneda
-converter.NumeroALetras(1234.56, { plural: 'PESOS', singular: 'PESO' });
-// "MIL DOSCIENTOS TREINTA Y CUATRO PESOS 56/100 M.N"
-
-converter.NumeroALetras(1, { plural: 'PESOS', singular: 'PESO' });
-// "UN PESO 00/100 M.N"
-
-converter.NumeroALetras(1000000);
-// "UN MILLON"
-```
-
-### Logo
-
-```typescript
-import { Logo } from '@cfdi/utils';
-
-const logo = new Logo();
-// Manejo de logos para representacion impresa de CFDI
-```
-
-### Utilidades de archivo
-
-```typescript
-import { isPath } from '@cfdi/utils';
-
-// Detecta si un string es una ruta de archivo o contenido directo
-isPath('/ruta/archivo.xml'); // true
-isPath('<xml>contenido</xml>'); // false
-```
-
-## API
-
-| Export | Tipo | Descripcion |
-|--------|------|-------------|
-| `NumeroALetras` | clase | Convierte numeros a texto en español con formato de moneda |
-| `Logo` | clase | Manejo de logos para PDF |
-| `File` | clase | Utilidades de lectura de archivos |
-| `isPath(input)` | funcion | Detecta si un string es ruta o contenido |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/xml/README.md
+++ b/packages/cfdi/xml/README.md
@@ -310,18 +310,6 @@ const cfdiSaxon = new CFDI({
 
 ---
 
-## Compatibilidad
-
-| Version CFDI | Soportado |
-| ------------ | --------- |
-| 4.0          | Si        |
-| 3.3          | Si        |
-| 3.2          | Si        |
-
-**Complementos soportados:** Pagos 2.0, Nomina 1.2, Comercio Exterior 2.0, Carta Porte 3.1, Impuestos Locales, INE, Donatarias, Vehiculo Usado, entre otros.
-
----
-
 ## API
 
 | Metodo                       | Descripcion                                           |
@@ -375,7 +363,7 @@ interface Config {
 
 <p align="center">
   <a href="https://github.com/MisaelMa">
-    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="450" />
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
   </a>
 </p>
 

--- a/packages/cfdi/xml2json/README.md
+++ b/packages/cfdi/xml2json/README.md
@@ -1,6 +1,128 @@
-# @cfdi/2json
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/2json">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/2json" width="400" />
+  </a>
+</p>
 
-Conversion de XML de CFDI a JSON. Acepta una ruta de archivo o un string de XML y retorna un objeto JSON estructurado.
+<h3 align="center">Conversion de XML CFDI a JSON para Node.js</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/2json">
+    <img src="https://img.shields.io/npm/v/@cfdi/2json?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/2json">
+    <img src="https://img.shields.io/npm/dm/@cfdi/2json?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,42 +130,31 @@ Conversion de XML de CFDI a JSON. Acepta una ruta de archivo o un string de XML 
 npm install @cfdi/2json
 ```
 
-## Uso
+---
 
-```typescript
-import { XmlToJson } from '@cfdi/2json';
+## Soporte
 
-// Desde archivo
-const json = XmlToJson('/ruta/al/cfdi.xml');
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/2json">
+    <img src="https://img.shields.io/badge/npm-@cfdi/2json-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Desde string XML
-const xml = '<cfdi:Comprobante xmlns:cfdi="..." Version="4.0">...</cfdi:Comprobante>';
-const json2 = XmlToJson(xml);
-
-// Mantener namespaces originales (por defecto se eliminan)
-const jsonOriginal = XmlToJson('/ruta/al/cfdi.xml', { original: true });
-// Con namespaces: { 'cfdi:Comprobante': { ... } }
-// Sin namespaces (default): { Comprobante: { ... } }
-
-// Modo compact
-const jsonCompact = XmlToJson('/ruta/al/cfdi.xml', { compact: true });
-```
-
-## API
-
-### `XmlToJson(xmlPath, config?)`
-
-| Parametro | Tipo | Descripcion |
-|-----------|------|-------------|
-| `xmlPath` | `string` | Ruta a un archivo XML o string con contenido XML |
-| `config.original` | `boolean` | Si es `true`, mantiene los prefijos de namespace. Por defecto `false` |
-| `config.compact` | `boolean` | Si es `true`, usa formato compacto. Por defecto `false` |
-
-**Retorna:** Objeto JSON con la estructura del CFDI. Los namespaces como `cfdi:` se eliminan por defecto para facilitar el acceso a los nodos.
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/cfdi/xsd/README.md
+++ b/packages/cfdi/xsd/README.md
@@ -1,6 +1,128 @@
-# @cfdi/xsd
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/xsd">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="400" />
+  </a>
+</p>
 
-Validacion de CFDI contra esquemas XSD del SAT usando JSON Schema (AJV). Proporciona validadores para cada seccion del comprobante fiscal digital.
+<h3 align="center">Validacion de CFDI contra esquemas XSD oficiales del SAT</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@cfdi/xsd">
+    <img src="https://img.shields.io/npm/v/@cfdi/xsd?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/xsd">
+    <img src="https://img.shields.io/npm/dm/@cfdi/xsd?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,58 +130,31 @@ Validacion de CFDI contra esquemas XSD del SAT usando JSON Schema (AJV). Proporc
 npm install @cfdi/xsd
 ```
 
-## Uso
+---
 
-```typescript
-import Schema from '@cfdi/xsd';
+## Soporte
 
-// Obtener instancia singleton
-const schema = Schema.of();
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@cfdi/xsd">
+    <img src="https://img.shields.io/badge/npm-@cfdi/xsd-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Configurar ruta a los esquemas JSON
-schema.setConfig({
-  path: '/ruta/a/schemas',
-  debug: false,
-});
-
-// Validar secciones del comprobante
-const validadorComprobante = schema.cfdi.comprobante;
-const validadorEmisor = schema.cfdi.emisor;
-const validadorReceptor = schema.cfdi.receptor;
-const validadorImpuestos = schema.cfdi.impuestos;
-const validadorTraslado = schema.cfdi.traslado;
-const validadorRetencion = schema.cfdi.retencion;
-const validadorInfoGlobal = schema.cfdi.informacionGlobal;
-const validadorRelacionados = schema.cfdi.relacionados;
-const validadorRelacionado = schema.cfdi.relacionado;
-
-// Validar conceptos
-const validadorConcepto = schema.concepto.concepto;
-const validadorParte = schema.concepto.parte;
-const validadorPredial = schema.concepto.predial;
-const validadorInfoAduanera = schema.concepto.informacionAduanera;
-const validadorTrasladoConcepto = schema.concepto.traslado;
-const validadorRetencionConcepto = schema.concepto.retencion;
-```
-
-## API
-
-### `Schema`
-
-Clase singleton que gestiona los esquemas de validacion.
-
-| Metodo/Propiedad | Descripcion |
-|------------------|-------------|
-| `Schema.of()` | Retorna la instancia singleton |
-| `setConfig({ path, debug })` | Configura la ruta a los archivos de esquema JSON y modo debug |
-| `cfdi` | Acceso a validadores del comprobante (comprobante, emisor, receptor, impuestos, etc.) |
-| `concepto` | Acceso a validadores de conceptos (concepto, parte, predial, traslado, retencion, etc.) |
-
-Los archivos de esquema deben estar en formato JSON generados a partir de los XSD oficiales del SAT.
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/clir/openssl/README.md
+++ b/packages/clir/openssl/README.md
@@ -1,6 +1,128 @@
-# @clir/openssl
+<p align="center">
+  <a href="https://www.npmjs.com/package/@clir/openssl">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="400" />
+  </a>
+</p>
 
-Wrapper de la CLI de OpenSSL para operaciones con certificados digitales. Proporciona una interfaz fluida (builder pattern) para construir y ejecutar comandos `x509` y `pkcs8`.
+<h3 align="center">Wrapper de OpenSSL CLI para certificados digitales del SAT</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@clir/openssl">
+    <img src="https://img.shields.io/npm/v/@clir/openssl?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@clir/openssl">
+    <img src="https://img.shields.io/npm/dm/@clir/openssl?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,98 +130,31 @@ Wrapper de la CLI de OpenSSL para operaciones con certificados digitales. Propor
 npm install @clir/openssl
 ```
 
-## Uso
+---
 
-### x509 - Operaciones con certificados
+## Soporte
 
-```typescript
-import { x509 } from '@clir/openssl';
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@clir/openssl">
+    <img src="https://img.shields.io/badge/npm-@clir/openssl-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-// Convertir certificado DER a PEM
-const pem = x509.inform('DER').in('certificado.cer').outform('PEM').run();
-
-// Obtener informacion del certificado
-const texto = x509.inform('DER').in('certificado.cer').noout().text().run();
-
-// Obtener llave publica
-const pubkey = x509.inform('DER').in('certificado.cer').noout().pubkey().run();
-
-// Obtener numero de serie
-const serial = x509.inform('DER').in('certificado.cer').noout().serial().run();
-
-// Obtener huella digital
-const fingerprint = x509.inform('DER').in('certificado.cer').noout().fingerprint().run();
-
-// Verificar si expira en N segundos
-const check = x509.inform('DER').in('certificado.cer').noout().checkend(86400).run();
-
-// Obtener solo el comando como string (sin ejecutar)
-const cmd = x509.inform('DER').in('certificado.cer').noout().text().cli();
-```
-
-### pkcs8 - Operaciones con llaves privadas
-
-```typescript
-import { pkcs8 } from '@clir/openssl';
-
-// Convertir llave privada DER a PEM con contrasena
-const pem = pkcs8
-  .inform('DER')
-  .in('llave.key')
-  .outform('PEM')
-  .passin('pass:contrasena123')
-  .run();
-
-// Convertir a formato tradicional sin cifrado
-const trad = pkcs8.topk8().traditional().nocrypt().run();
-
-// Obtener el comando sin ejecutar
-const cmd = pkcs8.inform('DER').in('llave.key').cli();
-```
-
-## API
-
-### `x509`
-
-Instancia con interfaz fluida para comandos OpenSSL x509.
-
-| Metodo | Descripcion |
-|--------|-------------|
-| `inform(format)` | Formato de entrada: `'DER'`, `'PEM'` |
-| `in(file)` | Archivo de entrada |
-| `outform(format)` | Formato de salida: `'DER'`, `'PEM'` |
-| `noout()` | No imprimir el certificado |
-| `text()` | Imprimir certificado en texto legible |
-| `pubkey()` | Extraer llave publica |
-| `serial()` | Obtener numero de serie |
-| `fingerprint()` | Obtener huella digital |
-| `checkend(seconds)` | Verificar expiracion |
-| `subject()` | Obtener subject del certificado |
-| `issuer()` | Obtener issuer del certificado |
-| `startdate()` | Fecha de inicio de validez |
-| `enddate()` | Fecha de fin de validez |
-| `run()` | Ejecutar el comando y retornar resultado |
-| `cli()` | Retornar el comando como string sin ejecutar |
-
-### `pkcs8`
-
-Instancia con interfaz fluida para comandos OpenSSL pkcs8.
-
-| Metodo | Descripcion |
-|--------|-------------|
-| `inform(format)` | Formato de entrada |
-| `in(file)` | Archivo de entrada |
-| `outform(format)` | Formato de salida |
-| `passin(pass)` | Contrasena de entrada (ej: `'pass:123'`) |
-| `topk8()` | Convertir a formato PKCS#8 |
-| `traditional()` | Usar formato tradicional |
-| `nocrypt()` | Sin cifrado |
-| `run()` | Ejecutar el comando y retornar resultado |
-| `cli()` | Retornar el comando como string sin ejecutar |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 

--- a/packages/clir/saxon-he/README.md
+++ b/packages/clir/saxon-he/README.md
@@ -1,6 +1,128 @@
-# @saxon-he/cli
+<p align="center">
+  <a href="https://www.npmjs.com/package/@saxon-he/cli">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="400" />
+  </a>
+</p>
 
-Wrapper de Saxon-HE para ejecutar transformaciones XSLT y consultas XPath desde Node.js. Proporciona una API fluida (builder pattern) que construye y ejecuta comandos Saxon-HE.
+<h3 align="center">Wrapper de Saxon-HE para transformaciones XSLT en Node.js</h3>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@saxon-he/cli">
+    <img src="https://img.shields.io/npm/v/@saxon-he/cli?style=flat-square&color=cb3837&label=npm" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@saxon-he/cli">
+    <img src="https://img.shields.io/npm/dm/@saxon-he/cli?style=flat-square&color=cb3837&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license" />
+  </a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js&logoColor=white" alt="node" />
+  <img src="https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="typescript" />
+</p>
+
+<p align="center">
+  <a href="https://cfdi.recreando.dev">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-documentacion.png" alt="Documentacion" width="300" />
+  </a>
+</p>
+
+---
+
+## Ecosistema CFDI
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/cfdi-ecosystem.png" alt="CFDI Ecosystem" width="600" />
+</p>
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xml.png" alt="@cfdi/xml" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/complementos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-complementos.png" alt="@cfdi/complementos" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xsd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-xsd.png" alt="@cfdi/xsd" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csd">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csd.png" alt="@cfdi/csd" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/csf">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-csf.png" alt="@cfdi/csf" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/catalogos">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-catalogos.png" alt="@cfdi/catalogos" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/transform">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-transform.png" alt="@cfdi/transform" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/elements">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-elements.png" alt="@cfdi/elements" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/types">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-types.png" alt="@cfdi/types" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/expresiones">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-expresiones.png" alt="@cfdi/expresiones" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/xml2json">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-2json.png" alt="@cfdi/xml2json" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/rfc">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-rfc.png" alt="@cfdi/rfc" width="100%" />
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@cfdi/utils">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/cfdi-utils.png" alt="@cfdi/utils" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@clir/openssl">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/clir-openssl.png" alt="@clir/openssl" width="100%" />
+      </a>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://www.npmjs.com/package/@saxon-he/cli">
+        <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/packages/saxon-he-cli.png" alt="@saxon-he/cli" width="100%" />
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
 
 ## Instalacion
 
@@ -8,113 +130,31 @@ Wrapper de Saxon-HE para ejecutar transformaciones XSLT y consultas XPath desde 
 npm install @saxon-he/cli
 ```
 
-Requiere tener el binario de Saxon-HE instalado en el sistema.
+---
 
-## Uso
+## Soporte
 
-### Transformacion XSLT
+<p>
+  <a href="https://github.com/MisaelMa/node-cfdi/issues">
+    <img src="https://img.shields.io/badge/GitHub-Issues-181717?style=for-the-badge&logo=github" alt="issues" />
+  </a>
+  <a href="https://github.com/MisaelMa/node-cfdi/discussions">
+    <img src="https://img.shields.io/badge/GitHub-Discussions-181717?style=for-the-badge&logo=github" alt="discussions" />
+  </a>
+  <a href="https://www.npmjs.com/package/@saxon-he/cli">
+    <img src="https://img.shields.io/badge/npm-@saxon-he/cli-cb3837?style=for-the-badge&logo=npm" alt="npm" />
+  </a>
+</p>
 
-```typescript
-import { Transform } from '@saxon-he/cli';
-
-const transform = new Transform({ binary: '/ruta/saxon-he' });
-
-const resultado = transform
-  .s('/ruta/archivo.xml')       // Archivo XML de entrada
-  .xsl('/ruta/estilos.xslt')   // Hoja de estilos XSLT
-  .warnings('silent')           // Silenciar advertencias
-  .run();                       // Ejecutar y obtener resultado
-
-console.log(resultado);
-```
-
-### Transformacion con salida a archivo
-
-```typescript
-const transform = new Transform({ binary: '/ruta/saxon-he' });
-
-transform
-  .s('/ruta/entrada.xml')
-  .xsl('/ruta/transformacion.xslt')
-  .o('/ruta/salida.html')      // Archivo de salida
-  .run();
-```
-
-### Consulta XQuery
-
-```typescript
-import { Query } from '@saxon-he/cli';
-
-const query = new Query({ binary: '/ruta/saxon-he' });
-
-const resultado = query
-  .s('/ruta/archivo.xml')
-  .qs('//elemento/@atributo')   // Consulta XQuery inline
-  .run();
-```
-
-### Consulta desde archivo
-
-```typescript
-const query = new Query({ binary: '/ruta/saxon-he' });
-
-const resultado = query
-  .s('/ruta/datos.xml')
-  .q('/ruta/consulta.xq')       // Archivo de consulta XQuery
-  .projection('on')
-  .run();
-```
-
-## API
-
-### Clase `Transform`
-
-Metodos principales para transformaciones XSLT:
-
-| Metodo | Descripcion |
-|--------|-------------|
-| `s(filename)` | Archivo XML de entrada |
-| `xsl(filename)` | Hoja de estilos XSLT |
-| `o(filename)` | Archivo de salida |
-| `im(modename)` | Modo inicial de la transformacion |
-| `it(template)` | Template inicial |
-| `warnings(level)` | Nivel de advertencias: `'silent'`, `'recover'`, `'fatal'` |
-| `a(option)` | Activar/desactivar resolvedores: `'on'`, `'off'` |
-| `run()` | Ejecutar el comando y retornar el resultado como string |
-
-### Clase `Query`
-
-Metodos principales para consultas XQuery/XPath:
-
-| Metodo | Descripcion |
-|--------|-------------|
-| `s(filename)` | Archivo XML de entrada |
-| `q(queryfile)` | Archivo de consulta XQuery |
-| `qs(querystring)` | Consulta XQuery inline |
-| `backup(option)` | Activar/desactivar backup: `'on'`, `'off'` |
-| `projection(option)` | Activar/desactivar proyeccion: `'on'`, `'off'` |
-| `stream(option)` | Activar/desactivar streaming: `'on'`, `'off'` |
-| `run()` | Ejecutar el comando y retornar el resultado como string |
-
-### Metodos compartidos (Transform y Query)
-
-Ambas clases heredan de `CliShare` y comparten estos metodos:
-
-| Metodo | Descripcion |
-|--------|-------------|
-| `o(filename)` | Archivo de salida |
-| `s(filename)` | Archivo XML de entrada |
-| `val(validation)` | Validacion: `'strict'`, `'lax'` |
-| `dtd(option)` | Procesamiento DTD |
-| `expand(option)` | Expansion de atributos |
-| `xsd(file)` | Archivo de esquema XSD |
-| `strip(option)` | Eliminacion de espacios en blanco |
-| `catalog(filenames)` | Catalogos XML |
-| `run()` | Ejecutar el comando |
+---
 
 ## Autor
 
-**Amir Misael Marin Coh** — [@MisaelMa](https://github.com/MisaelMa)
+<p align="center">
+  <a href="https://github.com/MisaelMa">
+    <img src="https://raw.githubusercontent.com/MisaelMa/cards/main/author.png" alt="Amir Misael Marin Coh" width="100%" />
+  </a>
+</p>
 
 ## Licencia
 


### PR DESCRIPTION
## Summary

- Update all 15 package READMEs with visual card images from `MisaelMa/cards` repo
- Add CFDI ecosystem table (15 cards grid) to every README
- Add npm, downloads, license, node, TypeScript badges
- Add documentation (`cfdi-documentacion.png`), ecosystem (`cfdi-ecosystem.png`) and author (`author.png`) images
- Document dual XSLT engine support in `@cfdi/xml` (`@cfdi/transform` default + `@saxon-he/cli` optional)

## Test plan

- [ ] Verify card images render correctly on GitHub
- [ ] Verify all npm links point to correct packages
- [ ] Verify documentation button links to cfdi.recreando.dev