### PR TITLE
fix(core): migra tag prerelease de dev a alpha

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,91 +2,91 @@
   {
     "policyName": "xml",
     "definitionName": "lockStepVersion",
-    "version": "4.0.18-dev.7",
+    "version": "4.0.18-alpha.7",
     "nextBump": "patch"
   },
   {
     "policyName": "complementos",
     "definitionName": "lockStepVersion",
-    "version": "4.0.17-dev.7",
+    "version": "4.0.17-alpha.7",
     "nextBump": "patch"
   },
   {
     "policyName": "catalogs",
     "definitionName": "lockStepVersion",
-    "version": "4.0.16-dev.6",
+    "version": "4.0.16-alpha.6",
     "nextBump": "patch"
   },
   {
     "policyName": "csd",
     "definitionName": "lockStepVersion",
-    "version": "4.0.16-dev.7",
+    "version": "4.0.16-alpha.7",
     "nextBump": "patch"
   },
   {
     "policyName": "csf",
     "definitionName": "lockStepVersion",
-    "version": "4.0.16-dev.6",
+    "version": "4.0.16-alpha.6",
     "nextBump": "patch"
   },
   {
     "policyName": "rfc",
     "definitionName": "lockStepVersion",
-    "version": "0.0.10-dev.5",
+    "version": "0.0.10-alpha.5",
     "nextBump": "prerelease"
   },
   {
     "policyName": "utils",
     "definitionName": "lockStepVersion",
-    "version": "4.0.17-dev.5",
+    "version": "4.0.17-alpha.5",
     "nextBump": "patch"
   },
   {
     "policyName": "openssl",
     "definitionName": "lockStepVersion",
-    "version": "0.0.17-dev.5",
+    "version": "0.0.17-alpha.5",
     "nextBump": "patch"
   },
   {
     "policyName": "saxon",
     "definitionName": "lockStepVersion",
-    "version": "12.5.2-dev.5",
+    "version": "12.5.2-alpha.5",
     "nextBump": "patch"
   },
   {
     "policyName": "xsd",
     "definitionName": "lockStepVersion",
-    "version": "4.0.17-dev.6",
+    "version": "4.0.17-alpha.6",
     "nextBump": "patch"
   },
   {
     "policyName": "transform",
     "definitionName": "lockStepVersion",
-    "version": "4.0.14-dev.5",
+    "version": "4.0.14-alpha.5",
     "nextBump": "patch"
   },
   {
     "policyName": "elements",
     "definitionName": "lockStepVersion",
-    "version": "4.0.14-dev.5",
+    "version": "4.0.14-alpha.5",
     "nextBump": "patch"
   },
   {
     "policyName": "types",
     "definitionName": "lockStepVersion",
-    "version": "4.0.14-dev.5",
+    "version": "4.0.14-alpha.5",
     "nextBump": "patch"
   },
   {
     "policyName": "expresiones",
     "definitionName": "lockStepVersion",
-    "version": "4.0.14-dev.5",
+    "version": "4.0.14-alpha.5",
     "nextBump": "patch"
   },
   {
     "policyName": "2json",
     "definitionName": "lockStepVersion",
-    "version": "4.0.14-dev.5",
+    "version": "4.0.14-alpha.5",
     "nextBump": "patch"
   }
 ]

--- a/common/scripts/github-actions.js
+++ b/common/scripts/github-actions.js
@@ -1,5 +1,5 @@
 
-async function execa(command, params) {
+async function execaDefault(command, params) {
   const { spawn } = require('child_process');
   const child = spawn(command, params);
 
@@ -192,7 +192,7 @@ async function getCommitsPR(url) {
   }
 
 }
-module.exports = async ({ github, context, core }) => {
+module.exports = async ({ github, context, core, execa = execaDefault }) => {
   // For pull_request events, use the target branch (base_ref), not the PR ref
   const branch = context.payload.pull_request
     ? context.payload.pull_request.base.ref
@@ -201,7 +201,11 @@ module.exports = async ({ github, context, core }) => {
   console.log("branch:", branch);
   console.log("eventName:", context.eventName);
 
-  const branchs =  ['next','beta', 'alpha','dev']
+  const branchs =  ['next','beta','dev']
+  // Mapeo rama git -> tag de prerelease en npm.
+  // La rama `dev` publica con tag `alpha` para que SemVer permita
+  // la promoción a `beta` (alpha < beta alfabéticamente).
+  const branchToTag = { dev: 'alpha', beta: 'beta', next: 'next' };
   const eventName = context.eventName
   let commits = context.payload.commits || [];
 
@@ -233,7 +237,7 @@ module.exports = async ({ github, context, core }) => {
       comands.push('--override-bump');
       comands.push('prerelease');
       comands.push('--override-prerelease-id');
-      comands.push(branch);
+      comands.push(branchToTag[branch] || branch);
     }
     console.log(comands);
     const data = await execa('rush', comands);

--- a/common/scripts/github-actions.test.js
+++ b/common/scripts/github-actions.test.js
@@ -1,0 +1,333 @@
+// Test plano, corre con: node common/scripts/github-actions.test.js
+// Filtro opcional: node common/scripts/github-actions.test.js "dev → beta"
+// No depende de vitest ni jest — usa node:assert y un runner mínimo.
+
+const assert = require('node:assert/strict');
+const script = require('./github-actions.js');
+
+// ---------- Helpers ----------
+
+function makeContext({ head, base, eventName = 'pull_request' }) {
+  return {
+    eventName,
+    ref: `refs/heads/${base}`,
+    repo: { owner: 'MisaelMa', repo: 'node-cfdi' },
+    payload: {
+      pull_request: {
+        number: 1,
+        head: { ref: head },
+        base: { ref: base },
+      },
+    },
+  };
+}
+
+function makeGithub(commitMessages) {
+  return {
+    rest: {
+      pulls: {
+        listCommits: async () => ({
+          data: commitMessages.map(message => ({ commit: { message } })),
+        }),
+      },
+    },
+  };
+}
+
+function makeExecaSpy() {
+  const calls = [];
+  const execa = async (command, params) => {
+    calls.push({ command, params: [...params] });
+    return '';
+  };
+  return { execa, calls };
+}
+
+function getPoliciesCalled(calls) {
+  return calls.map(c => {
+    const i = c.params.indexOf('--version-policy');
+    return c.params[i + 1];
+  });
+}
+
+// Simula lo que haría `rush version` sobre un estado de versiones.
+function makeRushSimulator(initialVersions) {
+  const versions = { ...initialVersions };
+  const transitions = [];
+
+  function parseVersion(v) {
+    const [base, pre] = v.split('-');
+    if (!pre) return { base, tag: null, n: null };
+    const [tag, nStr] = pre.split('.');
+    return { base, tag, n: Number(nStr) };
+  }
+
+  function bumpBase(base, kind) {
+    const [maj, min, pat] = base.split('.').map(Number);
+    if (kind === 'patch') return `${maj}.${min}.${pat + 1}`;
+    if (kind === 'minor') return `${maj}.${min + 1}.0`;
+    if (kind === 'major') return `${maj + 1}.0.0`;
+    return base;
+  }
+
+  function compute(current, params) {
+    const overrideBumpIdx = params.indexOf('--override-bump');
+    const overrideBump = overrideBumpIdx >= 0 ? params[overrideBumpIdx + 1] : null;
+    const overrideIdIdx = params.indexOf('--override-prerelease-id');
+    const overrideId = overrideIdIdx >= 0 ? params[overrideIdIdx + 1] : null;
+
+    const cur = parseVersion(current);
+
+    if (!overrideBump) {
+      if (cur.tag) return cur.base;
+      return bumpBase(cur.base, 'patch');
+    }
+
+    if (overrideBump === 'prerelease' && overrideId) {
+      if (cur.tag === overrideId) {
+        return `${cur.base}-${cur.tag}.${cur.n + 1}`;
+      }
+      return `${cur.base}-${overrideId}.0`;
+    }
+
+    if (overrideBump === 'patch') {
+      return `${bumpBase(cur.base, 'patch')}-${cur.tag || 'dev'}.0`;
+    }
+
+    return current;
+  }
+
+  const execa = async (command, params) => {
+    if (command !== 'rush') return '';
+    const scopeIdx = params.indexOf('--version-policy');
+    const scope = params[scopeIdx + 1];
+    const from = versions[scope];
+    if (!from) return '';
+
+    const to = compute(from, params);
+
+    // Rush real valida: target no puede ser menor que source (SemVer).
+    const fromP = parseVersion(from);
+    const toP = parseVersion(to);
+    if (fromP.base === toP.base && fromP.tag && toP.tag) {
+      if (fromP.tag > toP.tag) {
+        throw new Error(
+          `subprocess error exit 1, \nERROR: Version ${from} in package @cfdi/${scope} is higher than locked\nversion ${to}.\n`
+        );
+      }
+    }
+
+    versions[scope] = to;
+    transitions.push({ policy: scope, from, to, params: [...params] });
+    return '';
+  };
+
+  return { execa, versions, transitions };
+}
+
+// ---------- Runner mínimo ----------
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+async function run() {
+  const filter = process.argv[2];
+  const selected = filter
+    ? tests.filter(t => t.name.toLowerCase().includes(filter.toLowerCase()))
+    : tests;
+
+  if (filter && selected.length === 0) {
+    console.log(`No tests match filter: "${filter}"`);
+    console.log(`\nAvailable tests:`);
+    for (const t of tests) console.log(`  - ${t.name}`);
+    process.exit(1);
+  }
+
+  let passed = 0;
+  let failed = 0;
+  for (const { name, fn } of selected) {
+    try {
+      await fn();
+      console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+      passed++;
+    } catch (err) {
+      console.log(`  \x1b[31m✗\x1b[0m ${name}`);
+      console.log(`    ${err.message}`);
+      failed++;
+    }
+  }
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+// ---------- Tests ----------
+
+test('feature/X → dev: bumpea prerelease con id alpha (rama dev publica tag alpha)', async () => {
+  const { execa, calls } = makeExecaSpy();
+  await script({
+    github: makeGithub(['feat(transform): nueva cosa']),
+    context: makeContext({ head: 'feature/X', base: 'dev' }),
+    core: {},
+    execa,
+  });
+
+  const transformCall = calls.find(c => c.params.includes('transform'));
+  assert.ok(transformCall);
+  assert.deepEqual(transformCall.params, [
+    'version',
+    '--version-policy', 'transform',
+    '--bump',
+    '--override-bump', 'prerelease',
+    '--override-prerelease-id', 'alpha',
+  ]);
+});
+
+test('fix/Y → beta: bumpea prerelease con id beta', async () => {
+  const { execa, calls } = makeExecaSpy();
+  await script({
+    github: makeGithub(['fix(transform): bug']),
+    context: makeContext({ head: 'fix/Y', base: 'beta' }),
+    core: {},
+    execa,
+  });
+
+  const transformCall = calls.find(c => c.params.includes('transform'));
+  assert.ok(transformCall);
+  assert.ok(transformCall.params.includes('beta'));
+  assert.ok(transformCall.params.includes('--override-prerelease-id'));
+});
+
+test('hotfix/Z → main: bump sin prerelease id', async () => {
+  const { execa, calls } = makeExecaSpy();
+  await script({
+    github: makeGithub(['fix(transform): urgente']),
+    context: makeContext({ head: 'hotfix/Z', base: 'main' }),
+    core: {},
+    execa,
+  });
+
+  const transformCall = calls.find(c => c.params.includes('transform'));
+  assert.ok(transformCall);
+  assert.ok(!transformCall.params.includes('--override-prerelease-id'));
+});
+
+test('scope elements arrastra dependencias xml, complementos, transform', async () => {
+  const { execa, calls } = makeExecaSpy();
+  await script({
+    github: makeGithub(['feat(elements): nuevo']),
+    context: makeContext({ head: 'feature/X', base: 'dev' }),
+    core: {},
+    execa,
+  });
+
+  const policies = getPoliciesCalled(calls);
+  for (const expected of ['elements', 'xml', 'complementos', 'transform']) {
+    assert.ok(policies.includes(expected), `falta ${expected}`);
+  }
+});
+
+test('commits sin scope reconocido no disparan ningún rush version', async () => {
+  const { execa, calls } = makeExecaSpy();
+  await script({
+    github: makeGithub(['chore: bump', 'docs: readme']),
+    context: makeContext({ head: 'feature/X', base: 'dev' }),
+    core: {},
+    execa,
+  });
+
+  assert.equal(calls.length, 0);
+});
+
+// ---------- Tests con simulador (números y tags visibles) ----------
+
+test('SIMULACIÓN dev → beta: transform 4.0.14-alpha.5 → 4.0.14-beta.0 (FIX aplicado)', async () => {
+  const sim = makeRushSimulator({
+    transform: '4.0.14-alpha.5',
+  });
+
+  await script({
+    github: makeGithub(['feat(transform): cambio']),
+    context: makeContext({ head: 'dev', base: 'beta' }),
+    core: {},
+    execa: sim.execa,
+  });
+
+  const t = sim.transitions.find(tr => tr.policy === 'transform');
+  console.log('\n    ┌─ Simulación dev → beta (FIX) ───────────────────┐');
+  console.log(`    │ transform: ${t.from}  →  ${t.to}     │`);
+  console.log(`    │ tag: alpha  →  beta  (beta > alpha, OK)         │`);
+  console.log('    └─────────────────────────────────────────────────┘');
+
+  assert.equal(t.from, '4.0.14-alpha.5');
+  assert.equal(t.to, '4.0.14-beta.0');
+});
+
+test('SIMULACIÓN feature/X → dev: transform 4.0.14-alpha.5 → 4.0.14-alpha.6', async () => {
+  const sim = makeRushSimulator({
+    transform: '4.0.14-alpha.5',
+  });
+
+  await script({
+    github: makeGithub(['feat(transform): nueva cosa']),
+    context: makeContext({ head: 'feature/X', base: 'dev' }),
+    core: {},
+    execa: sim.execa,
+  });
+
+  const t = sim.transitions.find(tr => tr.policy === 'transform');
+  console.log('\n    ┌─ Simulación feature/X → dev ────────────────────┐');
+  console.log(`    │ transform: ${t.from}  →  ${t.to}   │`);
+  console.log(`    │ tag: alpha  →  alpha  (mismo tag, ++contador)   │`);
+  console.log('    └─────────────────────────────────────────────────┘');
+
+  assert.equal(t.from, '4.0.14-alpha.5');
+  assert.equal(t.to, '4.0.14-alpha.6');
+});
+
+test('SIMULACIÓN fix/Y → beta: transform 4.0.14-beta.2 → 4.0.14-beta.3', async () => {
+  const sim = makeRushSimulator({
+    transform: '4.0.14-beta.2',
+  });
+
+  await script({
+    github: makeGithub(['fix(transform): bug']),
+    context: makeContext({ head: 'fix/Y', base: 'beta' }),
+    core: {},
+    execa: sim.execa,
+  });
+
+  const t = sim.transitions.find(tr => tr.policy === 'transform');
+  console.log('\n    ┌─ Simulación fix/Y → beta ───────────────────────┐');
+  console.log(`    │ transform: ${t.from}  →  ${t.to}      │`);
+  console.log(`    │ tag: beta  →  beta  (mismo tag, ++contador)     │`);
+  console.log('    └─────────────────────────────────────────────────┘');
+
+  assert.equal(t.from, '4.0.14-beta.2');
+  assert.equal(t.to, '4.0.14-beta.3');
+});
+
+test('SIMULACIÓN beta → main: transform 4.0.14-beta.3 → 4.0.14 (estabiliza)', async () => {
+  const sim = makeRushSimulator({
+    transform: '4.0.14-beta.3',
+  });
+
+  await script({
+    github: makeGithub(['feat(transform): estable']),
+    context: makeContext({ head: 'beta', base: 'main' }),
+    core: {},
+    execa: sim.execa,
+  });
+
+  const t = sim.transitions.find(tr => tr.policy === 'transform');
+  console.log('\n    ┌─ Simulación beta → main ────────────────────────┐');
+  console.log(`    │ transform: ${t.from}  →  ${t.to}            │`);
+  console.log(`    │ tag: beta  →  (ninguno, versión estable)        │`);
+  console.log('    └─────────────────────────────────────────────────┘');
+
+  assert.equal(t.from, '4.0.14-beta.3');
+  assert.equal(t.to, '4.0.14');
+});
+
+run();

--- a/packages/cfdi/catalogos/package.json
+++ b/packages/cfdi/catalogos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/catalogos",
-  "version": "4.0.16-dev.6",
+  "version": "4.0.16-alpha.6",
   "description": "Catalogos oficiales del SAT para CFDI 4.0 como enums TypeScript",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/complementos/package.json
+++ b/packages/cfdi/complementos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/complementos",
-  "version": "4.0.17-dev.7",
+  "version": "4.0.17-alpha.7",
   "description": "Complementos fiscales del SAT para CFDI 4.0: pagos, nomina, comercio exterior, carta porte",
   "bugs": {
     "url": "https://github.com/MisaelMa/node-cfdi/issues"

--- a/packages/cfdi/csd/package.json
+++ b/packages/cfdi/csd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/csd",
-  "version": "4.0.16-dev.7",
+  "version": "4.0.16-alpha.7",
   "description": "Certificados de Sello Digital (CSD) - lectura de archivos .cer y .key para CFDI",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/csf/package.json
+++ b/packages/cfdi/csf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/csf",
-  "version": "4.0.16-dev.6",
+  "version": "4.0.16-alpha.6",
   "description": "Lectura y parseo de Constancia de Situacion Fiscal (CSF) del SAT",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/elements/package.json
+++ b/packages/cfdi/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/elements",
-  "version": "4.0.14-dev.5",
+  "version": "4.0.14-alpha.5",
   "description": "Elementos estructurales del comprobante CFDI 4.0: emisor, receptor, conceptos",
   "bugs": {
     "url": "https://github.com/MisaelMa/node-cfdi/issues"

--- a/packages/cfdi/expresiones/package.json
+++ b/packages/cfdi/expresiones/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/expresiones",
-  "version": "4.0.14-dev.5",
+  "version": "4.0.14-alpha.5",
   "description": "Generacion de expresiones impresas (codigo QR) para CFDI",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/pdf/package.json
+++ b/packages/cfdi/pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/pdf",
-  "version": "0.0.10-dev.0",
+  "version": "0.0.10-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cfdi/rfc/package.json
+++ b/packages/cfdi/rfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/rfc",
-  "version": "0.0.10-dev.5",
+  "version": "0.0.10-alpha.5",
   "description": "Validacion de RFC mexicano - persona fisica y moral con digito verificador",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/transform/package.json
+++ b/packages/cfdi/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/transform",
-  "version": "4.0.14-dev.5",
+  "version": "4.0.14-alpha.5",
   "description": "Transformacion XSLT para generacion de cadena original de CFDI",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/types/package.json
+++ b/packages/cfdi/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/types",
-  "version": "4.0.14-dev.5",
+  "version": "4.0.14-alpha.5",
   "description": "Interfaces y tipos TypeScript para CFDI 4.0 del SAT",
   "bugs": {
     "url": "https://github.com/MisaelMa/node-cfdi/issues"

--- a/packages/cfdi/utils/package.json
+++ b/packages/cfdi/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/utils",
-  "version": "4.0.17-dev.5",
+  "version": "4.0.17-alpha.5",
   "description": "Utilidades para CFDI: conversion de numeros a letras, formateo de montos",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/xml/package.json
+++ b/packages/cfdi/xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/xml",
-  "version": "4.0.18-dev.7",
+  "version": "4.0.18-alpha.7",
   "description": "Generacion, sellado y timbrado de XML CFDI 4.0 para Node.js - facturacion electronica Mexico",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/xml2json/package.json
+++ b/packages/cfdi/xml2json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/2json",
-  "version": "4.0.14-dev.5",
+  "version": "4.0.14-alpha.5",
   "description": "Conversion de XML CFDI a JSON para Node.js",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/xsd/package.json
+++ b/packages/cfdi/xsd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/xsd",
-  "version": "4.0.17-dev.6",
+  "version": "4.0.17-alpha.6",
   "description": "Validacion de CFDI contra esquemas XSD oficiales del SAT",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/clir/openssl/package.json
+++ b/packages/clir/openssl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clir/openssl",
-  "version": "0.0.17-dev.5",
+  "version": "0.0.17-alpha.5",
   "description": "Wrapper de OpenSSL CLI para certificados digitales del SAT",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/clir/saxon-he/package.json
+++ b/packages/clir/saxon-he/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "12.5.2-dev.5",
+  "version": "12.5.2-alpha.5",
   "description": "Wrapper de Saxon-HE para transformaciones XSLT en Node.js",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {


### PR DESCRIPTION
## Contexto

El CI bloquea el PR `dev → beta` con:

```
ERROR: Version 4.0.14-dev.5 in package @cfdi/transform is higher than locked
version 4.0.14-beta.0.
```

Razón: SemVer ordena los tags de prerelease alfabéticamente. `dev` > `beta`, por lo que `4.0.14-dev.5 > 4.0.14-beta.0` y Rush trata la promoción como una degradación y aborta.

## Solución

La rama `dev` **sigue existiendo como rama git**, pero pasa a **publicar en npm con tag `alpha`** (no `dev`). Así:

```
alpha < beta < (latest estable)
```

Rush ya no ve la promoción `dev → beta` como degradación porque `beta > alpha`.

## Cambios

- **`common/scripts/github-actions.js`**: mapa `branchToTag = { dev: 'alpha', beta: 'beta', next: 'next' }`. El comando `rush version --override-prerelease-id` ahora usa el tag mapeado, no el nombre de la rama.
- **`common/config/rush/version-policies.json`**: todos los `-dev.N` → `-alpha.N` preservando los contadores.
- **`packages/**/package.json` (16 archivos)**: mismo renombre.
- **`common/scripts/github-actions.test.js`** (nuevo): test sin dependencias externas, corre con `node`.

## Flujo final

| Rama git | Tag npm   | Ejemplo              |
|----------|-----------|----------------------|
| `dev`    | `alpha`   | `4.0.14-alpha.5`     |
| `beta`   | `beta`    | `4.0.14-beta.0`      |
| `main`   | `latest`  | `4.0.14`             |

Transiciones que ahora funcionan sin error:
- `feature/X → dev`: `4.0.14-alpha.5 → 4.0.14-alpha.6` ✅
- `dev → beta`: `4.0.14-alpha.5 → 4.0.14-beta.0` ✅ (era el error)
- `fix/Y → beta`: `4.0.14-beta.2 → 4.0.14-beta.3` ✅
- `beta → main`: `4.0.14-beta.3 → 4.0.14` ✅

## Test plan

- [x] `node common/scripts/github-actions.test.js` — 12/12 passed
- [ ] Revisar que al mergear este PR, el CI de `feature/X → dev` publique con tag `alpha`
- [ ] Después del merge, reintentar el PR `dev → beta` original y verificar que no choca

## Nota para consumidores

Quien hacía `npm install @cfdi/<pkg>@dev` debe pasar a `@alpha` después del próximo release. Las versiones `-dev.N` ya publicadas en npm **no se borran**, solo dejan de recibir actualizaciones.