### PR TITLE
feat(@signati/core): soporte HidroYPetro v1.0 (hidrocarburos y petrolíferos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,43 @@
-Recreando + CFDI
-Hace 6 meses se empezo a darle mantenimiento a paquetes de signati de forma indirecta especificamente de @signati/core. Este paquete genera el xml del cfdi, la contribucion fue con platicas para mejoras y exposicion de funciones internas, gracias a esto se planteo realizar mas paquetes para ayudar a las integraciones de factura de terceros.
+# @signati/core
 
-Por lo cual se crearon lo siguientes paquetes, algunos estan en proceso de desarollo para llegar a ser estables.
+> ## ⚠️ Paquete deprecado — migra a [`@cfdi/xml`](https://www.npmjs.com/package/@cfdi/xml)
+>
+> Este paquete **ya no recibe mantenimiento activo**. Esta release es un parche de compatibilidad para quienes deben seguir emitiendo CFDI 4.0 durante la transición, e incluye el nuevo complemento obligatorio **Hidrocarburos y Petrolíferos (`HidroYPetro` v1.0)** publicado por el SAT el 25-03-2026 y obligatorio desde el 24-04-2026.
+>
+> **Se recomienda fuertemente migrar cuanto antes** al nuevo ecosistema `@cfdi/*`, que reemplaza a `@signati/core` con mejoras de rendimiento, soporte nativo de AWS Lambda y mantenimiento continuo. Los futuros complementos y cambios del SAT solo se liberarán en los paquetes nuevos.
 
-Este paquete seguira funcionando pero no tendra mantenimiento, le recomendamos usar @cfdi/xml
+## Migración recomendada
 
-tendra mejoras en rendimiento y soportes a lambdas
-<ul type="list" start="1">
-<li type="listitem" value="1">
-<a href="https://www.npmjs.com/package/@cfdi/xml" rel="nofollow"><code>@cfdi/xml</code></a>
-</li>
-<li type="listitem" value="2">
-<a href="https://" rel="nofollow"><code>@cfdi/catalogos</code></a>
-</li>
-<li type="listitem" value="3">
-<a href="https://www.npmjs.com/package/@cfdi/csd" rel="nofollow"><code>@cfdi/csd</code></a>
-</li>
-<li type="listitem" value="4">
-<a href="https://" rel="nofollow"><code>@cfdi/utils</code></a>
-</li>
-<li type="listitem" value="5">
-<span>@cfdi/pdf</span>
-</li>
-<li type="listitem" value="6">
-<span>@cfdi/curp</span>
-</li>
-<li type="listitem" value="7">
-<span>@cfdi/csf</span>
-</li>
-<li type="listitem" value="7">
-<span>@cfdi/rfc</span>
-</li>
-</ul>
+| `@signati/core` (deprecado) | Reemplazo en `@cfdi/*` |
+|---|---|
+| Generación y sellado de XML CFDI | [`@cfdi/xml`](https://www.npmjs.com/package/@cfdi/xml) |
+| Catálogos del SAT | [`@cfdi/catalogos`](https://www.npmjs.com/package/@cfdi/catalogos) |
+| Certificados de Sello Digital (`.cer`/`.key`) | [`@cfdi/csd`](https://www.npmjs.com/package/@cfdi/csd) |
+| Utilidades generales | `@cfdi/utils` |
+| Generación de PDF | `@cfdi/pdf` |
+| Consulta de CURP | `@cfdi/curp` |
+| Constancia de Situación Fiscal (CSF) | `@cfdi/csf` |
+| Validación de RFC | `@cfdi/rfc` |
+
+### Por qué migrar
+
+- **Mantenimiento activo**: los complementos nuevos y cambios del SAT se agregan primero en `@cfdi/xml`.
+- **Rendimiento**: el motor XSLT nativo (`@cfdi/transform`) elimina la dependencia de Saxon/JDK para generar la cadena original, lo que habilita su uso en entornos serverless (AWS Lambda, Cloudflare Workers, Vercel).
+- **Modular**: instala solo los paquetes que necesitas en lugar de un monolito.
+- **Tipado completo**: tipos y enums de catálogos SAT generados desde los XSD oficiales.
+
+### Arranque rápido en `@cfdi/xml`
+
+```bash
+npm install @cfdi/xml @cfdi/catalogos @cfdi/csd @cfdi/complementos
+```
+
+La guía oficial de migración y ejemplos viven en la documentación del proyecto: https://cfdi.recreando.dev
+
+---
+
+## Contexto histórico
+
+Hace varios años este paquete (`@signati/core`) empezó a darle mantenimiento indirecto al ecosistema de facturación electrónica en México. Con el tiempo se decidió rediseñar el proyecto en una suite modular (`@cfdi/*`) para resolver limitaciones de empaquetado, rendimiento y mantenimiento a largo plazo.
+
+Puedes seguir usando `@signati/core` para emitir CFDI, pero ten en cuenta que **esta será una de las últimas versiones publicadas** y que no se agregarán complementos nuevos más allá del soporte de emergencia para `HidroYPetro`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@signati/core",
-  "version": "4.0.3",
+  "version": "4.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@signati/core",
-      "version": "4.0.3",
+      "version": "4.0.5",
       "license": "ISC",
       "dependencies": {
         "@signati/openssl": "^0.0.5",
@@ -47,6 +47,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
       "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.5.5",
         "@babel/generator": "^7.6.4",
@@ -7760,6 +7761,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
       "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8326,6 +8328,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
       "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "@babel/generator": "^7.6.4",
@@ -14537,7 +14540,8 @@
       "version": "3.7.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
       "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uglify-js": {
       "version": "3.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@signati/core",
-  "version": "4.0.4",
-  "description": "Crea el XML, Firmar Y Sella comprobantes fiscales digitales en Mexico (CFDI)",
+  "version": "4.0.5",
+  "description": "DEPRECATED - migra a @cfdi/xml. Crea el XML, Firmar Y Sella comprobantes fiscales digitales en Mexico (CFDI)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/src/signati/complements/hidrocarburos/hidroypetro/HidroYPetro.ts
+++ b/src/signati/complements/hidrocarburos/hidroypetro/HidroYPetro.ts
@@ -1,0 +1,29 @@
+import {
+    XmlHidroYPetro,
+    XmlHidroYPetroAttributes,
+} from '../../../types/Complements/hidrocarburos/hidroypetro/hidroypetro.com';
+import { ComplementsReturn } from '../../../types';
+
+export class HidroYPetro {
+    private hidroYPetro: XmlHidroYPetro = {} as XmlHidroYPetro;
+    private xmlns: string = 'http://www.sat.gob.mx/hidrocarburospetroliferos';
+    private xmlnskey: string = 'hidrocarburospetroliferos';
+    private schemaLocation: string[] = [
+        'http://www.sat.gob.mx/hidrocarburospetroliferos',
+        'http://www.sat.gob.mx/sitio_internet/cfd/hidrocarburospetroliferos/hidrocarburospetroliferos.xsd'
+    ];
+
+    constructor(attributes: XmlHidroYPetroAttributes) {
+        this.hidroYPetro._attributes = attributes;
+    }
+
+    public getComplement(): ComplementsReturn {
+        return {
+            key: 'hidrocarburospetroliferos:HidroYPetro',
+            xmlns: this.xmlns,
+            xmlnskey: this.xmlnskey,
+            schemaLocation: this.schemaLocation,
+            complement: this.hidroYPetro,
+        };
+    }
+}

--- a/src/signati/complements/hidrocarburos/hidroypetro/index.ts
+++ b/src/signati/complements/hidrocarburos/hidroypetro/index.ts
@@ -1,0 +1,4 @@
+import { HidroYPetro } from './HidroYPetro';
+
+export { HidroYPetro };
+export default HidroYPetro;

--- a/src/signati/complements/hidrocarburos/index.ts
+++ b/src/signati/complements/hidrocarburos/index.ts
@@ -1,5 +1,7 @@
 import { Ieeh } from './ieeh/Ieeh';
 import { Gceh } from './gceh';
+import { HidroYPetro } from './hidroypetro';
 
 export { Ieeh };
 export { Gceh };
+export { HidroYPetro };

--- a/src/signati/types/Complements/hidrocarburos/hidroypetro/hidroypetro.com.ts
+++ b/src/signati/types/Complements/hidrocarburos/hidroypetro/hidroypetro.com.ts
@@ -1,0 +1,35 @@
+export enum TipoPermisoHYP {
+    PER01 = 'PER01',
+    PER02 = 'PER02',
+    PER03 = 'PER03',
+    PER04 = 'PER04',
+    PER05 = 'PER05',
+    PER06 = 'PER06',
+    PER07 = 'PER07',
+    PER08 = 'PER08',
+    PER09 = 'PER09',
+    PER10 = 'PER10',
+    PER11 = 'PER11',
+}
+
+export enum SubProductoHYP {
+    SP16 = 'SP16', SP17 = 'SP17', SP18 = 'SP18', SP19 = 'SP19', SP20 = 'SP20',
+    SP21 = 'SP21', SP22 = 'SP22', SP23 = 'SP23', SP24 = 'SP24', SP25 = 'SP25',
+    SP26 = 'SP26', SP27 = 'SP27', SP28 = 'SP28', SP29 = 'SP29', SP30 = 'SP30',
+    SP31 = 'SP31', SP32 = 'SP32', SP33 = 'SP33', SP34 = 'SP34', SP35 = 'SP35',
+    SP36 = 'SP36', SP37 = 'SP37', SP38 = 'SP38', SP39 = 'SP39', SP40 = 'SP40',
+    SP41 = 'SP41', SP42 = 'SP42', SP43 = 'SP43', SP44 = 'SP44', SP45 = 'SP45',
+    SP46 = 'SP46', SP47 = 'SP47', SP48 = 'SP48',
+}
+
+export interface XmlHidroYPetro {
+    _attributes?: XmlHidroYPetroAttributes;
+}
+
+export interface XmlHidroYPetroAttributes {
+    Version: string;
+    TipoPermiso: TipoPermisoHYP | string;
+    NumeroPermiso: string;
+    ClaveHYP: string;
+    SubProductoHYP: SubProductoHYP | string;
+}

--- a/src/signati/types/Tags/complements.interface.ts
+++ b/src/signati/types/Tags/complements.interface.ts
@@ -40,8 +40,9 @@ import {ServicioParcial} from '../../complements/servicioparcial';
 import {XmlVehiculousado} from '../Complements/vehiculousado/vehiculousado.com';
 import {VehiculoUsado} from '../../complements/vehiculousado';
 import {XmlIeeh} from '../Complements/hidrocarburos/ieeh/ieeh.com';
-import {Gceh, Ieeh} from '../../complements/hidrocarburos';
+import {Gceh, HidroYPetro, Ieeh} from '../../complements/hidrocarburos';
 import {XmlGceh} from '../Complements/hidrocarburos/gceh/gceh.com';
+import {XmlHidroYPetro} from '../Complements/hidrocarburos/hidroypetro/hidroypetro.com';
 import {XmlImplocal} from '../Complements/implocal/implocal.com';
 import {Implocal} from '../../complements/implocal';
 import {XmlPfic} from '../Complements/pfic/pfic.com';
@@ -114,6 +115,8 @@ export interface XmlComplements extends anyKey {
 
 export interface XmlComplementsConcepts extends anyKey {
     'iedu:instEducativas'?: XmlIedu;
+    // https://www.sat.gob.mx/consulta/05122/complemento-hidrocarburos-y-petroliferos
+    'hidrocarburospetroliferos:HidroYPetro'?: XmlHidroYPetro;
     'ventavehiculos:VentaVehiculos'?: any;
     // https://github.com/facturacionmoderna/Comprobantes/blob/master/complementos/CFDI/venta_vehiculos/venta_vehiculos.xml
     'terceros:PorCuentadeTerceros'?: any; // https://github.com/facturacionmoderna/Comprobantes/blob/master/complementos/CFDI/terceros/terceros.xml
@@ -173,7 +176,8 @@ export declare type ComplementTypeXml =
     | XmlPfic
     | XmlTfd
     | XmlCartaPorte
-export declare type ComlementTypeConcept = Iedu;
+    | XmlHidroYPetro
+export declare type ComlementTypeConcept = Iedu | HidroYPetro;
 
 export interface ComplementsReturn extends ComplementProperties {
     complement: ComplementTypeXml;

--- a/src/signati/types/Tags/comprobante.interface.ts
+++ b/src/signati/types/Tags/comprobante.interface.ts
@@ -66,6 +66,7 @@ export interface XmlComprobanteAttributes extends Comprobante, anyKey {
     'xmlns:gceh'?: string; // http://www.sat.gob.mx/GastosHidrocarburos10
     /*########XmlComplementsConcepts#########3*/
     'xmlns:iedu'?: string; // http://www.sat.gob.mx/iedu
+    'xmlns:hidrocarburospetroliferos'?: string; // http://www.sat.gob.mx/hidrocarburospetroliferos
     'xmlns:ventavehiculos'?: string; // http://www.sat.gob.mx/ventavehiculos
     'xmlns:terceros'?: string; // http://www.sat.gob.mx/terceros
     'xmlns:aieps'?: string; // http://www.sat.gob.mx/acreditamiento


### PR DESCRIPTION
## Summary

Release de emergencia del paquete deprecado **`@signati/core`** para incorporar el nuevo complemento obligatorio **Hidrocarburos y Petrolíferos (`HidroYPetro` v1.0)** publicado por el SAT el 25-03-2026 y obligatorio desde el **24 de abril de 2026** para el sector energético. Closes #64.

- Nueva clase `HidroYPetro` a nivel concepto (`Comprobante/Conceptos/Concepto/ComplementoConcepto`) con namespace `http://www.sat.gob.mx/hidrocarburospetroliferos` y key `hidrocarburospetroliferos:HidroYPetro`.
- Enums `TipoPermisoHYP` (PER01–PER11) y `SubProductoHYP` (SP16–SP48).
- Registro en `XmlComplementsConcepts`, `ComlementTypeConcept` y `ComplementTypeXml`, más declaración `xmlns:hidrocarburospetroliferos` en `XmlComprobanteAttributes`.
- README actualizado con aviso de deprecación más visible y tabla de migración a `@cfdi/xml` / `@cfdi/catalogos` / `@cfdi/csd`, aclarando que este paquete no recibirá más complementos después de esta release de emergencia.
- Bump manual de patch `4.0.4` → `4.0.5` en `package.json` + `package-lock.json`.

## Referencias

- Issue: https://github.com/MisaelMa/node-cfdi/issues/64
- NPM histórico: https://www.npmjs.com/package/@signati/core?activeTab=versions
- Paquete recomendado para nuevas integraciones: https://www.npmjs.com/package/@cfdi/xml

## Test plan

- [x] `npm install` + `npm run build` (tsc pasa sin errores en la rama)
- [ ] Verificación manual: construir un CFDI con `concepto.complemento(new HidroYPetro({...}))` en un proyecto consumidor
- [ ] Publicar `@signati/core@4.0.5` a npm tras el merge y avisar a los consumidores en el issue #64