### PR TITLE
feat(xml): banner de donacion en modo desarrollo

### DIFF
--- a/packages/cfdi/xml/src/index.ts
+++ b/packages/cfdi/xml/src/index.ts
@@ -6,3 +6,30 @@ export * from './elements/Concepto';
 export { Concepto as Concepts } from './elements/Concepto';
 export * from './elements/Impuestos';
 export * from './types';
+
+const DONATION_FLAG = Symbol.for('@cfdi/xml.donation-shown');
+const env = (typeof process !== 'undefined' && process.env) || {};
+const isProd = env.NODE_ENV === 'production';
+const isTest =
+  env.NODE_ENV === 'test' || !!env.VITEST || !!env.JEST_WORKER_ID;
+const alreadyShown = (globalThis as any)[DONATION_FLAG] === true;
+
+if (!isProd && !isTest && !alreadyShown) {
+  (globalThis as any)[DONATION_FLAG] = true;
+  console.log(
+    [
+      '╔══════════════════════════════════════════════════════════╗',
+      '║  💛  ¿Te gusta @cfdi/xml?  ¡Apóyame con una donación!  💛 ║',
+      '╠══════════════════════════════════════════════════════════╣',
+      '║  ☕  Buy Me a Coffee:                                     ║',
+      '║      https://buymeacoffee.com/recreandodev               ║',
+      '║                                                          ║',
+      '║  ✉️   Correo:                                             ║',
+      '║      amisael.amir.misael@gmail.com                       ║',
+      '║      (escríbeme y te paso mi número de cuenta)           ║',
+      '║                                                          ║',
+      '║  🛠️   Este mensaje solo aparece en modo desarrollo        ║',
+      '╚══════════════════════════════════════════════════════════╝',
+    ].join('\n')
+  );
+}


### PR DESCRIPTION
## Resumen

Agrega un mensaje en consola al cargar `@cfdi/xml` invitando a donar via Buy Me a Coffee o correo.

- Solo se muestra cuando `NODE_ENV` no es `production` ni `test`.
- Suprime tambien si detecta corredores de tests (`VITEST`, `JEST_WORKER_ID`).
- Se imprime **una sola vez por proceso** usando un `Symbol.for` global como guard, robusto ante carga dual ESM+CJS.
- Incluye en el propio mensaje la nota "solo aparece en modo desarrollo" para que quede claro al usuario.

## Cambios

- [packages/cfdi/xml/src/index.ts](packages/cfdi/xml/src/index.ts): bloque `if (!isProd && !isTest && !alreadyShown)` despues de los re-exports.

## Test plan

- [ ] Dev: `node -e "require('./packages/cfdi/xml/dist/index.cjs')"` -> debe imprimir el banner.
- [ ] Prod: `NODE_ENV=production node -e "require('./packages/cfdi/xml/dist/index.cjs')"` -> sin salida.
- [ ] Tests: `rush test:ci` -> sin banner en stdout de tests.
- [ ] Doble import en el mismo proceso -> imprime una vez, no dos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)