### PR TITLE
feat: banner de donacion en modo desarrollo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,30 @@ export * from './signati/tags/Concepts';
 export * from './signati/tags/Impuestos';
 export * from './signati/complements/index';
 export * from './signati/types/index';
+
+const DONATION_FLAG = Symbol.for('@signati/core.donation-shown');
+const env = (typeof process !== 'undefined' && process.env) || {};
+const isProd = env.NODE_ENV === 'production';
+const isTest =
+  env.NODE_ENV === 'test' || !!env.VITEST || !!env.JEST_WORKER_ID;
+const alreadyShown = (globalThis as any)[DONATION_FLAG] === true;
+
+if (!isProd && !isTest && !alreadyShown) {
+  (globalThis as any)[DONATION_FLAG] = true;
+  console.log(
+    [
+      '╔══════════════════════════════════════════════════════════╗',
+      '║  💛  ¿Te gusta @signati/core?  ¡Apóyame con una donación! ║',
+      '╠══════════════════════════════════════════════════════════╣',
+      '║  ☕  Buy Me a Coffee:                                     ║',
+      '║      https://buymeacoffee.com/recreandodev               ║',
+      '║                                                          ║',
+      '║  ✉️   Correo:                                             ║',
+      '║      amisael.amir.misael@gmail.com                       ║',
+      '║      (escríbeme y te paso mi número de cuenta)           ║',
+      '║                                                          ║',
+      '║  🛠️   Este mensaje solo aparece en modo desarrollo        ║',
+      '╚══════════════════════════════════════════════════════════╝',
+    ].join('\n')
+  );
+}


### PR DESCRIPTION
## Resumen

Agrega un mensaje en consola al cargar `@signati/core` invitando a donar via Buy Me a Coffee o correo.

- Solo se muestra cuando `NODE_ENV` no es `production` ni `test`.
- Suprime tambien si detecta corredores de tests (`VITEST`, `JEST_WORKER_ID`).
- Se imprime **una sola vez por proceso** usando un `Symbol.for` global como guard.
- Incluye en el propio mensaje la nota "solo aparece en modo desarrollo" para que quede claro al usuario.

## Cambios

- [src/index.ts](src/index.ts): bloque `if (!isProd && !isTest && !alreadyShown)` despues de los re-exports.

## Test plan

- [ ] Dev: `node -e "require('./lib/index.js')"` -> debe imprimir el banner.
- [ ] Prod: `NODE_ENV=production node -e "require('./lib/index.js')"` -> sin salida.
- [ ] Tests: `npm test` -> sin banner en stdout de tests (jest setea `JEST_WORKER_ID`).
- [ ] Doble import en el mismo proceso -> imprime una vez, no dos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)