### PR TITLE
fix(publish): desbloquear publicacion de paquetes pendientes del bump

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -32,8 +32,8 @@
   {
     "policyName": "rfc",
     "definitionName": "lockStepVersion",
-    "version": "0.0.10-beta.0",
-    "nextBump": "prerelease"
+    "version": "0.0.10",
+    "nextBump": "patch"
   },
   {
     "policyName": "utils",
@@ -56,7 +56,7 @@
   {
     "policyName": "xsd",
     "definitionName": "lockStepVersion",
-    "version": "4.0.17-beta.0",
+    "version": "4.0.17",
     "nextBump": "patch"
   },
   {

--- a/packages/cfdi/rfc/package.json
+++ b/packages/cfdi/rfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/rfc",
-  "version": "0.0.10-beta.0",
+  "version": "0.0.10",
   "description": "Validacion de RFC mexicano - persona fisica y moral con digito verificador",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/packages/cfdi/xsd/package.json
+++ b/packages/cfdi/xsd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfdi/xsd",
-  "version": "4.0.17-beta.0",
+  "version": "4.0.17",
   "description": "Validacion de CFDI contra esquemas XSD oficiales del SAT",
   "homepage": "https://cfdi.recreando.dev",
   "bugs": {

--- a/rush.json
+++ b/rush.json
@@ -84,10 +84,7 @@
       "projectFolder": "packages/cfdi/xsd",
       "versionPolicyName": "xsd",
       "reviewCategory": "libraries",
-      "shouldPublish": true,
-      "tags": [
-        "beta"
-      ]
+      "shouldPublish": true
     },
     {
       "packageName": "@cfdi/schema",
@@ -147,10 +144,7 @@
       "projectFolder": "packages/cfdi/rfc",
       "versionPolicyName": "rfc",
       "reviewCategory": "libraries",
-      "shouldPublish": true,
-      "tags": [
-        "beta"
-      ]
+      "shouldPublish": true
     },
     {
       "packageName": "@clir/openssl",


### PR DESCRIPTION
## Contexto

El run [#24914886394](https://github.com/MisaelMa/node-cfdi/actions/runs/24914886394/job/72964767598) fallo en el step \`Publish (main)\` al intentar publicar \`@cfdi/rfc\` con el error:

> \`npm error You must specify a tag using --tag when publishing a prerelease version.\`

Como consecuencia, solo 7 paquetes del bump llegaron a npm y los 8 restantes quedaron pendientes. Peor aun: 3 de los 7 publicados referencian en sus \`dependencies\` versiones que **no existen en npm** porque son justamente los que no publicaron.

## Dependencias rotas en lo ya publicado

| Publicado | Depende de | Estado en npm |
|---|---|---|
| \`@cfdi/2json@4.0.14\` | \`@cfdi/utils@4.0.17\`, \`@cfdi/types@4.0.14\` | ❌ no existen |
| \`@cfdi/csd@4.0.16\` | \`@clir/openssl@0.0.17\` | ❌ no existe |
| \`@cfdi/elements@4.0.14\` | \`@cfdi/xsd@4.0.17\`, \`@saxon-he/cli@12.5.2\` | ❌ no existen |

## Causa

\`@cfdi/rfc\` y \`@cfdi/xsd\` tenian \`"tags": ["beta"]\` en \`rush.json\`. Para paquetes beta-tagged, rush **no strippea** el sufijo \`-beta.N\` en el \`version\` del propio paquete, pero **si lo strippea** al resolver \`workspace:*\` en las dependencias de otros paquetes. Resultado: \`@cfdi/elements@4.0.14\` publico declarando \`@cfdi/xsd@4.0.17\` (stable), pero el xsd mismo no pudo publicar como tal porque seguia como \`4.0.17-beta.0\` y el step \`Publish (main)\` no pasa \`--tag beta\`.

## Fix

Quito \`"tags": ["beta"]\` de \`@cfdi/xsd\` y \`@cfdi/rfc\` en \`rush.json\`. Ahora ambos se tratan como main y rush strippea \`-beta.X\` como hizo con los 7 exitosos. Los 8 paquetes pendientes publicaran en las versiones exactas que los 7 ya publicados esperan:

| Paquete | Version local | A publicar |
|---|---|---|
| \`@cfdi/utils\` | \`4.0.17-beta.0\` | \`4.0.17\` |
| \`@cfdi/types\` | \`4.0.14-beta.0\` | \`4.0.14\` |
| \`@clir/openssl\` | \`0.0.17-beta.0\` | \`0.0.17\` |
| \`@cfdi/xsd\` | \`4.0.17-beta.0\` | \`4.0.17\` |
| \`@saxon-he/cli\` | \`12.5.2-beta.0\` | \`12.5.2\` |
| \`@cfdi/transform\` | \`4.0.14-beta.0\` | \`4.0.14\` |
| \`@cfdi/xml\` | \`4.0.18-beta.2\` | \`4.0.18\` |
| \`@cfdi/rfc\` | \`0.0.10-beta.0\` | \`0.0.10\` |

## Test plan

- [ ] Al mergear el PR, el workflow \`publish.yml\` dispara sobre \`main\`
- [ ] Step \`Publish (main)\` pasa esta vez (no mas error \`--tag\` en rfc/xsd)
- [ ] Los 8 paquetes pendientes aparecen en npm en las versiones stable esperadas
- [ ] Los 7 previamente publicados se skippean (ya existen en registry)
- [ ] \`npm install @cfdi/2json\`, \`@cfdi/csd\` y \`@cfdi/elements\` resuelven correctamente sus deps